### PR TITLE
Umegaya/job release target

### DIFF
--- a/Deplo.toml
+++ b/Deplo.toml
@@ -114,7 +114,7 @@ runner = { type = "Machine", os = "Windows" }
 command = """
 source tools/scripts/setup_release_env.sh
 cargo build --release
-deplo vcs release-assets ${DEPLO_RELEASE_TAG} target/release/cli --replace -o name=deplo-Windows.exe
+deplo vcs release-assets ${DEPLO_RELEASE_TAG} target/release/cli --replace -o name=deplo-Windows
 """
 [ci.workflow.deploy.win.caches.cargo]
 keys = ["deploy-build-${{ runner.os }}-v1-${{ github.sha }}", "deploy-build-${{ runner.os }}-v1-"]

--- a/cli/src/command/ci.rs
+++ b/cli/src/command/ci.rs
@@ -41,7 +41,8 @@ impl<S: shell::Shell> CI<S> {
         };
         for (name, job) in jobs_and_kind.0 {
             let full_name = &format!("{}-{}", jobs_and_kind.1, name);
-            if vcs.changed(&job.patterns.iter().map(|p| p.as_ref()).collect()) {
+            if vcs.changed(&job.patterns.iter().map(|p| p.as_ref()).collect()) &&
+                job.release_target.as_ref().map_or_else(|| true, |t| config.runtime.release_target.as_ref() == Some(t)) {
                 log::debug!("========== invoking {}, pattern [{}] ==========", full_name, job.patterns.join(", "));
                 ci.mark_job_executed(&full_name)?;
             } else {

--- a/cli/src/command/ci.rs
+++ b/cli/src/command/ci.rs
@@ -42,7 +42,7 @@ impl<S: shell::Shell> CI<S> {
         for (name, job) in jobs_and_kind.0 {
             let full_name = &format!("{}-{}", jobs_and_kind.1, name);
             if vcs.changed(&job.patterns.iter().map(|p| p.as_ref()).collect()) &&
-                job.release_target.as_ref().map_or_else(|| true, |t| config.runtime.release_target.as_ref() == Some(t)) {
+                job.matches_current_release_target(&config.runtime.release_target) {
                 log::debug!("========== invoking {}, pattern [{}] ==========", full_name, job.patterns.join(", "));
                 ci.mark_job_executed(&full_name)?;
             } else {

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -101,7 +101,7 @@ pub enum Runner {
 #[derive(Serialize, Deserialize)]
 pub struct Job {
     pub account: Option<String>,
-    pub release_target: Option<String>,
+    pub for_targets: Option<Vec<String>>,
     pub patterns: Vec<String>,
     pub runner: Runner,
     pub shell: Option<String>,
@@ -168,6 +168,28 @@ impl Job {
                 h
             }
         };
+    }
+    pub fn matches_current_release_target(&self, target: &Option<String>) -> bool {
+        let t = match target {
+            Some(ref v) => v,
+            // if no target, always ok if for_targets is empty, otherwise not ok
+            None => return self.for_targets.is_none()
+        };
+        match &self.for_targets {
+            Some(ref v) => {
+                // here, both target and for_targets exists, compare matches
+                for target in v {
+                    if target == t {
+                        return true;
+                    }
+                }
+                return false;
+            },
+            None => {
+                // target exists, but for_targets is empty, always ok
+                return true;
+            }
+        }
     }
 }
 #[derive(Serialize, Deserialize)]

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -101,6 +101,7 @@ pub enum Runner {
 #[derive(Serialize, Deserialize)]
 pub struct Job {
     pub account: Option<String>,
+    pub release_target: Option<String>,
     pub patterns: Vec<String>,
     pub runner: Runner,
     pub shell: Option<String>,


### PR DESCRIPTION
- can control executed job per release target. eg) now you can job that only runs at production release
- set cli path for local host execution (not container), by modifying path for invoked process
