### PR TITLE
fix remote job payload to use Option<String> for describing commit

### DIFF
--- a/cli/src/command/ci.rs
+++ b/cli/src/command/ci.rs
@@ -89,7 +89,8 @@ impl<S: shell::Shell> CI<S> {
         let remote_job = config.ci_service_by_job_name(job_name)?.dispatched_remote_job()?;
         // if reach here by remote execution, adopt the settings, otherwise using cli options if any.
         let (commit, remote) = match remote_job {
-            Some(ref job) => (Some(job.commit.as_str()), false), // because this process already run in remote environment
+            // because this process already run in remote environment, remote is always false.
+            Some(ref job) => (job.commit.as_ref().map(|s| s.as_str()), false),
             None => (args.value_of("ref"), args.occurence_of("remote") > 0)
         };
         let may_remote_job_id = match args.subcommand() {

--- a/core/src/ci.rs
+++ b/core/src/ci.rs
@@ -10,7 +10,7 @@ use crate::module;
 #[derive(Serialize, Deserialize)]
 pub struct RemoteJob {
     pub name: String,
-    pub commit: String,
+    pub commit: Option<String>,
     pub command: String,
 }
 

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -878,7 +878,7 @@ impl Config {
             return Ok(Some(ci.run_job(&ci::RemoteJob{
                 name: name.to_string(),
                 command: cmd.to_string(),
-                commit: options.commit.unwrap_or("").to_string(),
+                commit: options.commit.map(|s| s.to_string()),
             })?));
         }
         match job.runner {
@@ -947,7 +947,7 @@ impl Config {
                     return Ok(Some(ci.run_job(&ci::RemoteJob{
                         name: name.to_string(),
                         command: cmd.to_string(),
-                        commit: options.commit.unwrap_or("").to_string(),
+                        commit: options.commit.map(|s| s.to_string()),
                     })?));
                 }
             },


### PR DESCRIPTION
commit == "" does not work because that is not None. it invokes invalid command `git reset --hard ""`