### PR TITLE
remove vcs::current_branch

### DIFF
--- a/core/src/ci/ghaction.rs
+++ b/core/src/ci/ghaction.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::config;
 use crate::ci;
 use crate::shell;
+use crate::vcs;
 use crate::module;
 use crate::util::{
     escalate,seal,
@@ -473,11 +474,11 @@ impl<S: shell::Shell> ci::CI for GhAction<S> {
                 }
             },
             Err(_) => {
-                let (name, is_branch) = config.vcs_service().unwrap().current_branch().unwrap();
-                if is_branch {
-                    envs.insert("DEPLO_CI_BRANCH_NAME", name);
+                let (ref_type, ref_path) = config.vcs_service().unwrap().current_ref().unwrap();
+                if ref_type == vcs::RefType::Tag {
+                    envs.insert("DEPLO_CI_TAG_NAME", ref_path);
                 } else {
-                    envs.insert("DEPLO_CI_TAG_NAME", name);
+                    envs.insert("DEPLO_CI_BRANCH_NAME", ref_path);
                 };
             }
         };

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -172,7 +172,8 @@ impl Job {
                 common_envs.insert("DEPLO_CI_RELEASE_TARGET", v.to_string());
             },
             None => {
-                log::info!("job_env: no release target: {}", config.vcs_service().unwrap().current_branch().unwrap().0);
+                let (ref_type, ref_path) = config.vcs_service().unwrap().current_ref().unwrap();
+                log::info!("job_env: no release target: {}/{}", ref_type, ref_path);
             }
         };
         match paths {
@@ -889,7 +890,9 @@ impl Config {
     pub fn recover_branch(&self) -> Result<(), Box<dyn Error>> {
         if !Self::is_running_on_ci() {
             let vcs = self.vcs_service()?;
-            if vcs.current_branch()?.0 == DEPLO_VCS_TEMPORARY_WORKSPACE_NAME {
+            let (ref_type, ref_path) = vcs.current_ref()?;
+            if ref_type == vcs::RefType::Branch &&
+                ref_path == DEPLO_VCS_TEMPORARY_WORKSPACE_NAME {
                 log::debug!("back to previous branch");
                 vcs.checkout("-", None)?;
             }

--- a/core/src/vcs.rs
+++ b/core/src/vcs.rs
@@ -16,12 +16,22 @@ pub enum RefType {
     Pull,
     Commit,
 }
+impl fmt::Display for RefType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Branch => write!(f, "branch"),
+            Self::Remote => write!(f, "remote"),
+            Self::Tag => write!(f, "tag"),
+            Self::Pull => write!(f, "pull"),
+            Self::Commit => write!(f, "commit"),
+        }
+    }
+}
 
 pub trait VCS : module::Module {
     fn new(config: &config::Container) -> Result<Self, Box<dyn Error>> where Self : Sized;
     fn release_target(&self) -> Option<String>;
     fn current_ref(&self) -> Result<(RefType, String), Box<dyn Error>>;
-    fn current_branch(&self) -> Result<(String, bool), Box<dyn Error>>;
     fn commit_hash(&self, expr: Option<&str>) -> Result<String, Box<dyn Error>>;
     fn checkout(&self, commit: &str, branch_name: Option<&str>) -> Result<(), Box<dyn Error>>;
     fn repository_root(&self) -> Result<String, Box<dyn Error>>;


### PR DESCRIPTION
current_branch causes error for detached HEAD, which often happen when we run remote job with --ref option