### PR TITLE
Umegaya/windows fix

### DIFF
--- a/Deplo.toml
+++ b/Deplo.toml
@@ -9,10 +9,10 @@ debug = { ghaction_deplo_debugger = "on", ghaction_job_debugger = "on" }
 # release target branch settings
 [common.release_targets]
 # main branch will be released as nightly
-nightly = { type = "Branch", path = "main" }
-lab = { type = "Branch", path = "lab" }
+nightly = { type = "Branch", paths = ["main"] }
+lab = { type = "Branch", paths = ["lab"] }
 # tag which name is started with numerals treated as release (eg. 0.1.10)
-prod = { type = "Tag", path = "[0-9]*" }
+prod = { type = "Tag", paths = ["[0-9]*"] }
 
 # ------------
 # vcs settings

--- a/cli/src/command/init.rs
+++ b/cli/src/command/init.rs
@@ -6,7 +6,7 @@ use log;
 use core::args;
 use core::config;
 use core::shell;
-use core::util::rm;
+use core::util::{rm, path_join};
 
 use crate::command;
 
@@ -29,10 +29,8 @@ impl<S: shell::Shell, A: args::Args> command::Command<A> for Init<S> {
         config::Config::prepare_ci(&self.config, reinit == "all" || reinit == "ci")?;
         config::Config::prepare_vcs(&self.config, reinit == "all" || reinit == "vcs")?;
         let config = self.config.borrow();
-        let mut data_path = config.deplo_data_path()?;
-        data_path.push("..");
-        data_path.push("deplow");
-        rm(&data_path);
+        let data_path = config.deplo_data_path()?;
+        rm(&path_join(vec![data_path.to_str().unwrap(), "..", "deplow"]));
         fs::write(&data_path, config.generate_wrapper_script())?;
         self.shell.exec(&vec!["chmod", "+x", data_path.to_str().unwrap()], shell::no_env(), shell::no_cwd(), &shell::no_capture())?;
         return Ok(())

--- a/cli/src/command/init.rs
+++ b/cli/src/command/init.rs
@@ -29,8 +29,8 @@ impl<S: shell::Shell, A: args::Args> command::Command<A> for Init<S> {
         config::Config::prepare_ci(&self.config, reinit == "all" || reinit == "ci")?;
         config::Config::prepare_vcs(&self.config, reinit == "all" || reinit == "vcs")?;
         let config = self.config.borrow();
-        let data_path = config.deplo_data_path()?;
-        rm(&path_join(vec![data_path.to_str().unwrap(), "..", "deplow"]));
+        let data_path = path_join(vec![config.deplo_data_path()?.to_str().unwrap(), "..", "deplow"]);
+        rm(&data_path);
         fs::write(&data_path, config.generate_wrapper_script())?;
         self.shell.exec(&vec!["chmod", "+x", data_path.to_str().unwrap()], shell::no_env(), shell::no_cwd(), &shell::no_capture())?;
         return Ok(())

--- a/core/res/cli/deplow.sh.tmpl
+++ b/core/res/cli/deplow.sh.tmpl
@@ -3,6 +3,7 @@ CWD=$(cd $(dirname ${{BASH_SOURCE[0]}}) && pwd)
 OS=$(uname -s)
 if [[ "${{OS}}" =~ ^MINGW.*|^MSYS.*|^CYGWIN.* ]]; then
     DEPLO_BIN_PATH_POSTFIX="Windows.exe"
+    OS="Windows"
 else
     DEPLO_BIN_PATH_POSTFIX="${{OS}}"
 fi

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -764,8 +764,8 @@ impl Config {
         Ok(path)
     }
     pub fn deplo_cli_download(&self, os: RunnerOS, shell: &impl shell::Shell) -> Result<PathBuf, Box<dyn Error>> {
-        let base = self.deplo_data_path()?;
-        let file_path = path_join(vec![base.to_str().unwrap(), "cli", DEPLO_VERSION, os.uname(), "deplo"]);
+        let base_path = path_join(vec![self.deplo_data_path()?.to_str().unwrap(), "cli", DEPLO_VERSION, os.uname()]);
+        let file_path = path_join(vec![base_path.to_str().unwrap(), "deplow"]);
         match fs::metadata(&file_path) {
             Ok(mata) => {
                 if mata.is_dir() {
@@ -778,7 +778,7 @@ impl Config {
             },
             Err(_) => {}
         };
-        fs::create_dir_all(&base)?;
+        fs::create_dir_all(&base_path)?;
         shell.download(&cli_download_url(os, DEPLO_VERSION), &file_path.to_str().unwrap(), true)?;
         return Ok(file_path);
     }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -23,7 +23,8 @@ use crate::util::{
     make_absolute,
     defer,
     randombytes_as_string,
-    rm
+    rm,
+    path_join
 };
 
 pub const DEPLO_GIT_HASH: &'static str = env!("GIT_HASH");
@@ -763,12 +764,8 @@ impl Config {
         Ok(path)
     }
     pub fn deplo_cli_download(&self, os: RunnerOS, shell: &impl shell::Shell) -> Result<PathBuf, Box<dyn Error>> {
-        let mut base = self.deplo_data_path()?;
-        base.push("cli");
-        base.push(DEPLO_VERSION);
-        base.push(os.uname());
-        let mut file_path = base.clone();
-        file_path.push("deplo");
+        let base = self.deplo_data_path()?;
+        let file_path = path_join(vec![base.to_str().unwrap(), "cli", DEPLO_VERSION, os.uname(), "deplo"]);
         match fs::metadata(&file_path) {
             Ok(mata) => {
                 if mata.is_dir() {

--- a/deplow
+++ b/deplow
@@ -3,6 +3,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)
 OS=$(uname -s)
 if [[ "${OS}" =~ ^MINGW.*|^MSYS.*|^CYGWIN.* ]]; then
     DEPLO_BIN_PATH_POSTFIX="Windows.exe"
+    OS="Windows"
 else
     DEPLO_BIN_PATH_POSTFIX="${OS}"
 fi


### PR DESCRIPTION
- fix MSYS path building (must use / on windows. eg. gitbash)
- download windows binary to .deplo/cli/$version/Windows/deplo-Windows.exe, instead of uname output (its like MSYS-NT.10.0 blah blah... on MSYS environment)