### PR TITLE
using homebrew version of toml-rs to enable multiline inline table

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
         "request": "launch",
         "program": "${workspaceFolder}/target/debug/cli",
         "args": [
-            "-v=3", "-r=prod", "i", "config"
+            "-v=3", "-r=prod", "i", "src"
         ]
     },    
     {
@@ -43,7 +43,7 @@
         "request": "launch",
         "program": "${workspaceFolder}/target/debug/cli",
         "args": [
-            "-v=3", "d", "src"
+            "-v=3", "d", "mac"
         ]
     },
     {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,8 +692,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 [[package]]
 name = "toml"
 version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+source = "git+https://github.com/umegaya/toml-rs?rev=2fd1713#2fd1713f0dfcb438a9330b5ac4065932029b0ce3"
 dependencies = [
  "serde",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simple_logger = "1.6.0"
-toml = "0.5.6"
+toml = { git = "https://github.com/umegaya/toml-rs", rev = "2fd1713" }
 sodalite = { git = "https://github.com/suntomi/sodalite" }
 tempfile = "3.2.0"
 


### PR DESCRIPTION
I know toml-rs authors don't want to support multiline inline table, because of the fear that toml becoming like JSON