### PR TITLE
introduce steps

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,5 +54,14 @@
         "args": [
             "init"
         ]
+    },
+    {
+        "name": "Steps",
+        "type": "lldb",
+        "request": "launch",
+        "program": "${workspaceFolder}/target/debug/cli",
+        "args": [
+            "-v=3", "-r", "nightly", "d", "mac", "steps"
+        ]
     }]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 [[package]]
 name = "toml"
 version = "0.5.8"
-source = "git+https://github.com/umegaya/toml-rs?rev=ee539d1#ee539d1a5a15ec49d4602d5654c1512875242d52"
+source = "git+https://github.com/umegaya/toml-rs?rev=93292f8#93292f8dcabddabb70cee9cc3bd22064c5bd40f5"
 dependencies = [
  "serde",
 ]

--- a/Deplo.toml
+++ b/Deplo.toml
@@ -99,7 +99,47 @@ patterns = ["Deplo.toml"]
 # local_fallback can be path to docker file. if you specify docker file path, deplo automatically build corresponding image
 # and use it as local fallback container image.
 runner = { type = "Machine", os = "Linux", local_fallback = { path = "tools/docker/Dockerfile.vmfb", shell = "sh" } }
-command = "deplo init"
+steps = [{
+    command = """
+if [ "$(echo $HOGE)" = "hoge" ]; then
+    echo "env does not work"
+    exit 1
+fi
+if [ ! -z "$(ls -al envs.md)" ]; then
+    ls -al
+    echo "workdir does not work"
+    exit 1
+fi
+if [ "$(echo $0)" = "sh" ]; then
+    echo "shell does not work"
+    exit 1
+fi
+""",
+    env = { HOGE = "hoge" },
+    shell = "sh",
+    workdir = "docs"
+}, {
+    command = "deplo init"
+}, {
+    command = """
+if [ "$(echo $FUGA)" = "fuga" ]; then
+    echo "env does not work"
+    exit 1
+fi
+if [ 1 -z "$(ls -al launch.json)" ]; then
+    ls -al
+    echo "workdir does not work"
+    exit 1
+fi
+if [ "$(echo $0)" = "bash" ]; then
+    echo "shell does not work"
+    exit 1
+fi
+""",    
+    env = { FUGA = "fuga" },
+    shell = "bash",
+    workdir = ".vscode"
+}]
 # commits settings. if path of files that changed after the job finish running, matched patterns, 
 # deplo push or made pull request such a changes to repoisitory, after all jobs finish running.
 commits = [

--- a/Deplo.toml
+++ b/Deplo.toml
@@ -77,7 +77,7 @@ done
 }
 
 [jobs.integrate.src]
-patterns = ["*/src/*", "Cargo.*",]
+patterns = ["*/src/*", "Cargo.*"]
 runner = { type = "Machine", os = "Linux", local_fallback = { image = "ghcr.io/suntomi/deplo:builder" } }
 command = "cargo build"
 tasks = { test = "cargo test", home = "echo ${HOME}" }
@@ -91,7 +91,7 @@ caches = {
         keys = ["integrate-build-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}"], # each os and Cargo.lock definition
         # paths root are also CI specific
         paths = ["target", "~/.cargo/bin", "~/.cargo/registry/cache", "~/.cargo/registry/index", "~/.cargo/git/db"] # all possible cargo cache paths
-    }, # last comma also valid
+    }
 }
 
 [jobs.integrate.config]
@@ -161,14 +161,6 @@ if [ $(deplo d product output foo) != "bar" ]; then
     exit 1
 fi
 """
-tasks = {
-    build = """
-set -e
-mkdir -p tools/docker/bin
-. tools/scripts/setup_release_env.sh
-sh tools/scripts/build_linux.sh
-"""
-}
 
 [jobs.deploy.latest]
 depends = ["product"]
@@ -188,62 +180,22 @@ docker push ghcr.io/suntomi/deplo:latest
 depends = ["product"]
 patterns = ["*/src/*", "Cargo.*"]
 runner = { type = "Machine", os = "MacOS" }
-steps = [{
-    name = "before test"
-    env = { HOGE = "hoge" },
-    workdir = "docs",
-    shell = "sh",
-    command = """
-    if [ "$(echo $HOGE)" != "hoge" ]; then
-        echo "env does not work"
-        exit 1
-    fi
-    if [ -z "$(ls -al ./envs.md)" ]; then
-        ls -al
-        echo "workdir does not work"
-        exit 1
-    fi
-    if [ "$(echo $0)" != "sh" ]; then
-        echo "shell does not work"
-        exit 1
-    fi
-    """
-}, {
-    command = """
-    set -e
-    . tools/scripts/setup_release_env.sh
-    cargo build --release
-    deplo vcs release-assets ${DEPLO_RELEASE_TAG} target/release/cli --replace -o name=deplo-Darwin
-    # deploy-mac depends on deploy-product, so can use its output
-    if [ "$(deplo d product output foo)" != "bar" ]; then
-        echo "failed to get output from deploy-product"
-        exit 1
-    fi
-    """
-}, {
-    name = "after test"
-    env = { FUGA = "fuga" },
-    shell = "bash",
-    workdir = ".vscode",
-    command = """
-    if [ "$(echo $FUGA)" != "fuga" ]; then
-        echo "env does not work"
-        exit 1
-    fi
-    if [ -z "$(ls -al launch.json)" ]; then
-        ls -al
-        echo "workdir does not work"
-        exit 1
-    fi
-    if [ "$(echo $0)" != "bash" ]; then
-        echo "shell does not work"
-        exit 1
-    fi
-    """,
-}]
-caches.cargo = {
-    keys = ["integrate-build-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}"],
-    paths = ["target", "~/.cargo/bin", "~/.cargo/registry/cache", "~/.cargo/registry/index", "~/.cargo/git/db"]
+command = """
+set -e
+. tools/scripts/setup_release_env.sh
+cargo build --release
+deplo vcs release-assets ${DEPLO_RELEASE_TAG} target/release/cli --replace -o name=deplo-Darwin
+# deploy-mac depends on deploy-product, so can use its output
+if [ $(deplo d product output foo) != "bar" ]; then
+    echo "failed to get output from deploy-product"
+    exit 1
+fi
+"""
+caches = {
+    cargo = {
+        keys = ["integrate-build-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}"],
+        paths = ["target", "~/.cargo/bin", "~/.cargo/registry/cache", "~/.cargo/registry/index", "~/.cargo/git/db"]
+    }
 }
 
 [jobs.deploy.win]

--- a/Deplo.toml
+++ b/Deplo.toml
@@ -180,6 +180,7 @@ docker push ghcr.io/suntomi/deplo:latest
 depends = ["product"]
 patterns = ["*/src/*", "Cargo.*"]
 runner = { type = "Machine", os = "MacOS" }
+steps = [{
 command = """
 set -e
 . tools/scripts/setup_release_env.sh
@@ -191,6 +192,7 @@ if [ $(deplo d product output foo) != "bar" ]; then
     exit 1
 fi
 """
+}]
 caches.cargo = {
     keys = ["integrate-build-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}"],
     paths = ["target", "~/.cargo/bin", "~/.cargo/registry/cache", "~/.cargo/registry/index", "~/.cargo/git/db"]

--- a/Deplo.toml
+++ b/Deplo.toml
@@ -100,6 +100,7 @@ patterns = ["Deplo.toml"]
 # and use it as local fallback container image.
 runner = { type = "Machine", os = "Linux", local_fallback = { path = "tools/docker/Dockerfile.vmfb", shell = "sh" } }
 steps = [{
+    name = "before test"
     env = { HOGE = "hoge" },
     workdir = "docs",
     shell = "sh",
@@ -121,6 +122,7 @@ steps = [{
 }, {
     command = "deplo init"
 }, {
+    name = "after test"
     env = { FUGA = "fuga" },
     shell = "bash",
     workdir = ".vscode",

--- a/Deplo.toml
+++ b/Deplo.toml
@@ -77,7 +77,7 @@ done
 }
 
 [jobs.integrate.src]
-patterns = ["*/src/*", "Cargo.*"]
+patterns = ["*/src/*", "Cargo.*",]
 runner = { type = "Machine", os = "Linux", local_fallback = { image = "ghcr.io/suntomi/deplo:builder" } }
 command = "cargo build"
 tasks = { test = "cargo test", home = "echo ${HOME}" }
@@ -91,7 +91,7 @@ caches = {
         keys = ["integrate-build-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}"], # each os and Cargo.lock definition
         # paths root are also CI specific
         paths = ["target", "~/.cargo/bin", "~/.cargo/registry/cache", "~/.cargo/registry/index", "~/.cargo/git/db"] # all possible cargo cache paths
-    }
+    }, # last comma also valid
 }
 
 [jobs.integrate.config]
@@ -191,11 +191,9 @@ if [ $(deplo d product output foo) != "bar" ]; then
     exit 1
 fi
 """
-caches = {
-    cargo = {
-        keys = ["integrate-build-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}"],
-        paths = ["target", "~/.cargo/bin", "~/.cargo/registry/cache", "~/.cargo/registry/index", "~/.cargo/git/db"]
-    }
+caches.cargo = {
+    keys = ["integrate-build-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}"],
+    paths = ["target", "~/.cargo/bin", "~/.cargo/registry/cache", "~/.cargo/registry/index", "~/.cargo/git/db"]
 }
 
 [jobs.deploy.win]

--- a/Deplo.toml
+++ b/Deplo.toml
@@ -99,49 +99,7 @@ patterns = ["Deplo.toml"]
 # local_fallback can be path to docker file. if you specify docker file path, deplo automatically build corresponding image
 # and use it as local fallback container image.
 runner = { type = "Machine", os = "Linux", local_fallback = { path = "tools/docker/Dockerfile.vmfb", shell = "sh" } }
-steps = [{
-    name = "before test"
-    env = { HOGE = "hoge" },
-    workdir = "docs",
-    shell = "sh",
-    command = """
-    if [ "$(echo $HOGE)" = "hoge" ]; then
-        echo "env does not work"
-        exit 1
-    fi
-    if [ ! -z "$(ls -al envs.md)" ]; then
-        ls -al
-        echo "workdir does not work"
-        exit 1
-    fi
-    if [ "$(echo $0)" = "sh" ]; then
-        echo "shell does not work"
-        exit 1
-    fi
-    """
-}, {
-    command = "deplo init"
-}, {
-    name = "after test"
-    env = { FUGA = "fuga" },
-    shell = "bash",
-    workdir = ".vscode",
-    command = """
-    if [ "$(echo $FUGA)" = "fuga" ]; then
-        echo "env does not work"
-        exit 1
-    fi
-    if [ 1 -z "$(ls -al launch.json)" ]; then
-        ls -al
-        echo "workdir does not work"
-        exit 1
-    fi
-    if [ "$(echo $0)" = "bash" ]; then
-        echo "shell does not work"
-        exit 1
-    fi
-    """,
-}]
+command = "deplo init"
 # commits settings. if path of files that changed after the job finish running, matched patterns, 
 # deplo push or made pull request such a changes to repoisitory, after all jobs finish running.
 commits = [
@@ -223,17 +181,57 @@ depends = ["product"]
 patterns = ["*/src/*", "Cargo.*"]
 runner = { type = "Machine", os = "MacOS" }
 steps = [{
-command = """
-set -e
-. tools/scripts/setup_release_env.sh
-cargo build --release
-deplo vcs release-assets ${DEPLO_RELEASE_TAG} target/release/cli --replace -o name=deplo-Darwin
-# deploy-mac depends on deploy-product, so can use its output
-if [ $(deplo d product output foo) != "bar" ]; then
-    echo "failed to get output from deploy-product"
-    exit 1
-fi
-"""
+    name = "before test"
+    env = { HOGE = "hoge" },
+    workdir = "docs",
+    shell = "sh",
+    command = """
+    if [ "$(echo $HOGE)" = "hoge" ]; then
+        echo "env does not work"
+        exit 1
+    fi
+    if [ ! -z "$(ls -al envs.md)" ]; then
+        ls -al
+        echo "workdir does not work"
+        exit 1
+    fi
+    if [ "$(echo $0)" = "sh" ]; then
+        echo "shell does not work"
+        exit 1
+    fi
+    """
+}, {
+    command = """
+    set -e
+    . tools/scripts/setup_release_env.sh
+    cargo build --release
+    deplo vcs release-assets ${DEPLO_RELEASE_TAG} target/release/cli --replace -o name=deplo-Darwin
+    # deploy-mac depends on deploy-product, so can use its output
+    if [ $(deplo d product output foo) != "bar" ]; then
+        echo "failed to get output from deploy-product"
+        exit 1
+    fi
+    """
+}, {
+    name = "after test"
+    env = { FUGA = "fuga" },
+    shell = "bash",
+    workdir = ".vscode",
+    command = """
+    if [ "$(echo $FUGA)" = "fuga" ]; then
+        echo "env does not work"
+        exit 1
+    fi
+    if [ 1 -z "$(ls -al launch.json)" ]; then
+        ls -al
+        echo "workdir does not work"
+        exit 1
+    fi
+    if [ "$(echo $0)" = "bash" ]; then
+        echo "shell does not work"
+        exit 1
+    fi
+    """,
 }]
 caches.cargo = {
     keys = ["integrate-build-${{ runner.os }}-v1-${{ hashFiles('**/Cargo.lock') }}"],

--- a/Deplo.toml
+++ b/Deplo.toml
@@ -100,45 +100,45 @@ patterns = ["Deplo.toml"]
 # and use it as local fallback container image.
 runner = { type = "Machine", os = "Linux", local_fallback = { path = "tools/docker/Dockerfile.vmfb", shell = "sh" } }
 steps = [{
-    command = """
-if [ "$(echo $HOGE)" = "hoge" ]; then
-    echo "env does not work"
-    exit 1
-fi
-if [ ! -z "$(ls -al envs.md)" ]; then
-    ls -al
-    echo "workdir does not work"
-    exit 1
-fi
-if [ "$(echo $0)" = "sh" ]; then
-    echo "shell does not work"
-    exit 1
-fi
-""",
     env = { HOGE = "hoge" },
+    workdir = "docs",
     shell = "sh",
-    workdir = "docs"
+    command = """
+    if [ "$(echo $HOGE)" = "hoge" ]; then
+        echo "env does not work"
+        exit 1
+    fi
+    if [ ! -z "$(ls -al envs.md)" ]; then
+        ls -al
+        echo "workdir does not work"
+        exit 1
+    fi
+    if [ "$(echo $0)" = "sh" ]; then
+        echo "shell does not work"
+        exit 1
+    fi
+    """
 }, {
     command = "deplo init"
 }, {
-    command = """
-if [ "$(echo $FUGA)" = "fuga" ]; then
-    echo "env does not work"
-    exit 1
-fi
-if [ 1 -z "$(ls -al launch.json)" ]; then
-    ls -al
-    echo "workdir does not work"
-    exit 1
-fi
-if [ "$(echo $0)" = "bash" ]; then
-    echo "shell does not work"
-    exit 1
-fi
-""",    
     env = { FUGA = "fuga" },
     shell = "bash",
-    workdir = ".vscode"
+    workdir = ".vscode",
+    command = """
+    if [ "$(echo $FUGA)" = "fuga" ]; then
+        echo "env does not work"
+        exit 1
+    fi
+    if [ 1 -z "$(ls -al launch.json)" ]; then
+        ls -al
+        echo "workdir does not work"
+        exit 1
+    fi
+    if [ "$(echo $0)" = "bash" ]; then
+        echo "shell does not work"
+        exit 1
+    fi
+    """,
 }]
 # commits settings. if path of files that changed after the job finish running, matched patterns, 
 # deplo push or made pull request such a changes to repoisitory, after all jobs finish running.

--- a/Deplo.toml
+++ b/Deplo.toml
@@ -194,16 +194,16 @@ steps = [{
     workdir = "docs",
     shell = "sh",
     command = """
-    if [ "$(echo $HOGE)" = "hoge" ]; then
+    if [ "$(echo $HOGE)" != "hoge" ]; then
         echo "env does not work"
         exit 1
     fi
-    if [ ! -z "$(ls -al envs.md)" ]; then
+    if [ -z "$(ls -al ./envs.md)" ]; then
         ls -al
         echo "workdir does not work"
         exit 1
     fi
-    if [ "$(echo $0)" = "sh" ]; then
+    if [ "$(echo $0)" != "sh" ]; then
         echo "shell does not work"
         exit 1
     fi
@@ -215,7 +215,7 @@ steps = [{
     cargo build --release
     deplo vcs release-assets ${DEPLO_RELEASE_TAG} target/release/cli --replace -o name=deplo-Darwin
     # deploy-mac depends on deploy-product, so can use its output
-    if [ $(deplo d product output foo) != "bar" ]; then
+    if [ "$(deplo d product output foo)" != "bar" ]; then
         echo "failed to get output from deploy-product"
         exit 1
     fi
@@ -226,16 +226,16 @@ steps = [{
     shell = "bash",
     workdir = ".vscode",
     command = """
-    if [ "$(echo $FUGA)" = "fuga" ]; then
+    if [ "$(echo $FUGA)" != "fuga" ]; then
         echo "env does not work"
         exit 1
     fi
-    if [ 1 -z "$(ls -al launch.json)" ]; then
+    if [ -z "$(ls -al launch.json)" ]; then
         ls -al
         echo "workdir does not work"
         exit 1
     fi
-    if [ "$(echo $0)" = "bash" ]; then
+    if [ "$(echo $0)" != "bash" ]; then
         echo "shell does not work"
         exit 1
     fi

--- a/Deplo.toml
+++ b/Deplo.toml
@@ -161,6 +161,14 @@ if [ $(deplo d product output foo) != "bar" ]; then
     exit 1
 fi
 """
+tasks = {
+    build = """
+set -e
+mkdir -p tools/docker/bin
+. tools/scripts/setup_release_env.sh
+sh tools/scripts/build_linux.sh
+"""
+}
 
 [jobs.deploy.latest]
 depends = ["product"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simple_logger = "1.6.0"
-toml = { git = "https://github.com/umegaya/toml-rs", rev = "ee539d1" }
+toml = { git = "https://github.com/umegaya/toml-rs", rev = "93292f8" }
 sodalite = { git = "https://github.com/suntomi/sodalite" }
 tempfile = "3.2.0"
 

--- a/core/src/args/clap.rs
+++ b/core/src/args/clap.rs
@@ -113,6 +113,9 @@ fn job_running_command_options(
             .required(true)
             .takes_value(true)))
     .subcommand(
+        App::new("steps")
+        .about("run all steps of the job. designed to be used by deplo itself, you seldom can utilize this command"))
+    .subcommand(
         App::new("output")
         .about("get output, data passed between jobs, of specified job")
         .arg(Arg::new("key")

--- a/core/src/ci.rs
+++ b/core/src/ci.rs
@@ -11,7 +11,7 @@ use crate::module;
 pub struct RemoteJob {
     pub name: String,
     pub commit: Option<String>,
-    pub command: String,
+    pub command: Option<String>,
     pub envs: HashMap<String, String>,
     pub verbosity: u64,
     pub release_target: Option<String>,

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -171,6 +171,7 @@ pub struct SystemJobEnvOptions {
     pub job_name: String,
 }
 #[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
 pub enum Step {
     Command {
         command: String,


### PR DESCRIPTION
steps is a set of shell command. you can declare multiple shell command by separated __step__. wait, but can not we invoke set of shell command just by invoking multiple commands in  `job.command`? why is it required? 

because each step can have different set of shell, workdir, additional environment variable setting. thus step is useful to introduce module. most of module invoke some command for their environment (eg. setup prerequisite cli,  login and get credential of some service), and usually required isolated settings of their command invocation.

