### PR TITLE
improve builder image

### DIFF
--- a/Deplo.toml
+++ b/Deplo.toml
@@ -155,23 +155,22 @@ docker buildx build ${push_opt} --platform linux/amd64,linux/arm64 -t ghcr.io/su
 
 [jobs.builder]
 # if workflows is opmitted, use ["deploy", "integrate"] by default.
-on = { workflows = ["deploy","integrate"], changed = ["tools/docker/Dockerfile.builder", "Cargo.*"] }
+on = { workflows = ["deploy"], changed = ["tools/docker/Dockerfile.builder", "Cargo.*"] }
 runner = { os = "linux", local_fallback = { image = "docker:25.0.1", shell = "sh" } }
 command = """
 set -e
 sh tools/scripts/copy_manifests.sh
-docker buildx create --name mp --bootstrap --use
-push_opt=""
-if [ "${DEPLO_CI_WORKFLOW_NAME}" = "deploy" ]; then
-    echo ${SUNTOMI_VCS_ACCOUNT_KEY} | docker login ghcr.io -u ${SUNTOMI_VCS_ACCOUNT} --password-stdin
-    push_opt="--push"
-fi
 case "$(uname -m)" in
     x86_64) arch=amd64 ;;
     aarch64) arch=arm64 ;;
     *) echo "unsupported architecture"; exit 1 ;;
 esac
-docker buildx build ${push_opt} --platform linux/${arch} -t ghcr.io/suntomi/deplo:builder-${arch} -f tools/docker/Dockerfile.builder tools/docker
+docker build --platform linux/${arch} -t ghcr.io/suntomi/deplo:builder-${arch} -f tools/docker/Dockerfile.builder tools/docker
+if [ "${DEPLO_CI_WORKFLOW_NAME}" = "deploy" ]; then
+    echo ${SUNTOMI_VCS_ACCOUNT_KEY} | docker login ghcr.io -u ${SUNTOMI_VCS_ACCOUNT} --password-stdin
+    docker push ghcr.io/suntomi/deplo:builder-${arch}
+fi
+sh ./tools/scripts/merge_manifests.sh
 """
 # tasks. task is a pre-defined command to be executed in same environment as job.
 # you can use tasks to use deplo like repository of utility command, like make or rake.
@@ -182,7 +181,8 @@ for i in `seq 1 ${COUNT:-10}`; do
     sleep 1
 done
 """,
-    test = "sh ./tools/scripts/longrun.sh 5"
+    test = "sh ./tools/scripts/longrun.sh 5",
+    merge = "sh ./tools/scripts/merge_manifests.sh"
 }
 
 [jobs.test]

--- a/Deplo.toml
+++ b/Deplo.toml
@@ -155,7 +155,7 @@ docker buildx build ${push_opt} --platform linux/amd64,linux/arm64 -t ghcr.io/su
 
 [jobs.builder]
 # if workflows is opmitted, use ["deploy", "integrate"] by default.
-on = { workflows = ["deploy"], changed = ["tools/docker/Dockerfile.builder", "Cargo.*"] }
+on = { workflows = ["deploy","integrate"], changed = ["tools/docker/Dockerfile.builder", "Cargo.*"] }
 runner = { os = "linux", local_fallback = { image = "docker:25.0.1", shell = "sh" } }
 command = """
 set -e
@@ -166,7 +166,12 @@ if [ "${DEPLO_CI_WORKFLOW_NAME}" = "deploy" ]; then
     echo ${SUNTOMI_VCS_ACCOUNT_KEY} | docker login ghcr.io -u ${SUNTOMI_VCS_ACCOUNT} --password-stdin
     push_opt="--push"
 fi
-docker buildx build ${push_opt} --platform linux/amd64,linux/arm64 -t ghcr.io/suntomi/deplo:builder -f tools/docker/Dockerfile.builder tools/docker
+case "$(uname -m)" in
+    x86_64) arch=amd64 ;;
+    aarch64) arch=arm64 ;;
+    *) echo "unsupported architecture"; exit 1 ;;
+esac
+docker buildx build ${push_opt} --platform linux/${arch} -t ghcr.io/suntomi/deplo:builder-${arch} -f tools/docker/Dockerfile.builder tools/docker
 """
 # tasks. task is a pre-defined command to be executed in same environment as job.
 # you can use tasks to use deplo like repository of utility command, like make or rake.

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/suntomi/deplo:builder as builder
+FROM --platform=${BUILDPLATFORM} ghcr.io/suntomi/deplo:builder as builder
 
 ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}

--- a/tools/docker/Dockerfile.builder
+++ b/tools/docker/Dockerfile.builder
@@ -1,25 +1,49 @@
-FROM rust:slim
-
-ARG TARGETARCH
-ENV TARGETARCH=${TARGETARCH}
-RUN apt update && apt install -y git musl-tools musl-dev curl perl make xz-utils
+FROM --platform=${BUILDPLATFORM} debian:bookworm-slim as zig
+RUN apt update && apt install -y curl xz-utils
 # 0.11.0 has lfs64 linker error with cargo-zigbuild https://github.com/ziglang/zig/issues/15610
 ENV ZIG_VERSION="0.10.1"
-RUN if [ "${TARGETARCH}" = "arm64" ]; then export ARCH="aarch64"; else export ARCH="x86_64"; fi && \
+RUN if [ "${BUILDPLATFORM}" = "arm64" ]; then export ARCH="aarch64"; else export ARCH="x86_64"; fi && \
     curl -LO https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${ARCH}-${ZIG_VERSION}.tar.xz && \
-    tar -xf zig-linux-${ARCH}-${ZIG_VERSION}.tar.xz && \
-    mv zig-linux-${ARCH}-${ZIG_VERSION}/zig /usr/local/bin/ && \
-    mv zig-linux-${ARCH}-${ZIG_VERSION}/lib /usr/local/bin/ && \
+    tar -xf zig-linux-${ARCH}-${ZIG_VERSION}.tar.xz && mkdir -p /opt/zig && \
+    mv zig-linux-${ARCH}-${ZIG_VERSION}/zig /opt/zig/ && \
+    mv zig-linux-${ARCH}-${ZIG_VERSION}/lib /opt/zig/ && ls -al /opt/zig/ && \
     rm -rf zig-linux-${ARCH}-${ZIG_VERSION}.tar.xz zig-linux-${ARCH}-${ZIG_VERSION}
-ENV OPENSSL_VERSION="3.2.1"
-RUN if [ "${TARGETARCH}" = "arm64" ]; then export ARCH="aarch64"; else export ARCH="x86_64"; fi && \
-    curl -L https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz \
+
+FROM --platform=${BUILDPLATFORM} debian:bookworm-slim as builder-x86_64
+COPY --from=zig /opt/zig/zig /usr/local/bin/zig
+COPY --from=zig /opt/zig/lib /usr/local/bin/lib
+RUN ls -al /usr/local/bin
+RUN apt update && apt install -y curl perl make
+ENV OPENSSL_VERSION="3.2.1" ARCH="x86_64"
+RUN curl -L https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz \
     -o /tmp/opensslg.tgz && tar -zxvf /tmp/opensslg.tgz -C /tmp && cd /tmp/openssl-${OPENSSL_VERSION} && \
     CC="zig cc -target ${ARCH}-linux-musl" AR="zig ar" ./Configure no-shared no-async linux-${ARCH} && \
     make depend && make -j$(nproc) && make install_sw && \
     rm -f /tmp/opensslg.tgz && rm -rf /tmp/openssl-${OPENSSL_VERSION}    
-RUN if [ "${TARGETARCH}" = "arm64" ]; then export ARCH="aarch64"; else export ARCH="x86_64"; fi && \
-    rustup target add ${ARCH}-unknown-linux-musl && cargo install cargo-zigbuild
+
+FROM --platform=${BUILDPLATFORM} debian:bookworm-slim as builder-aarch64
+COPY --from=zig /opt/zig/zig /usr/local/bin/zig
+COPY --from=zig /opt/zig/lib /usr/local/bin/lib
+RUN ls -al /usr/local/bin
+RUN apt update && apt install -y curl perl make
+ENV OPENSSL_VERSION="3.2.1" ARCH="aarch64"
+RUN curl -L https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz \
+    -o /tmp/opensslg.tgz && tar -zxvf /tmp/opensslg.tgz -C /tmp && cd /tmp/openssl-${OPENSSL_VERSION} && \
+    CC="zig cc -target ${ARCH}-linux-musl" AR="zig ar" ./Configure no-shared no-async linux-${ARCH} && \
+    make depend && make -j$(nproc) && make install_sw && \
+    rm -f /tmp/opensslg.tgz && rm -rf /tmp/openssl-${OPENSSL_VERSION}    
+
+FROM --platform=${BUILDPLATFORM} rust:slim
+COPY --from=zig /opt/zig/zig /usr/local/bin/zig
+COPY --from=zig /opt/zig/lib /usr/local/bin/lib
+RUN rustup target add x86_64-unknown-linux-musl && cargo install cargo-zigbuild && \
+    rustup target add aarch64-unknown-linux-musl && cargo install cargo-zigbuild
+RUN mkdir -p /usr/local/x86_64/lib && mkdir -p /usr/local/aarch64/lib && \
+    mkdir -p /usr/local/x86_64/include && mkdir -p /usr/local/aarch64/include
+COPY --from=builder-x86_64 /usr/local/include/openssl /usr/local/x86_64/include/openssl
+COPY --from=builder-x86_64 /usr/local/lib64/* /usr/local/x86_64/lib/
+COPY --from=builder-aarch64 /usr/local/include/openssl /usr/local/aarch64/include/openssl
+COPY --from=builder-aarch64 /usr/local/lib/* /usr/local/aarch64/lib/
 
 # precompile dependency crates and store above path
 ENV CARGO_BUILD_TARGET_DIR=/tmp/target
@@ -34,14 +58,16 @@ COPY ./manifests/cli/Cargo.* cli
 COPY ./manifests/core/Cargo.* core
 ENV PKG_CONFIG_ALLOW_CROSS=1
 ENV OPENSSL_STATIC=true
-ENV OPENSSL_DIR=/usr/local
 # remove build result cache to force rebuild with actual project
-RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-        export ARCH="aarch64"; \
-        export OPENSSL_LIB_DIR="/usr/local/lib"; \
-    else \
-        export ARCH="x86_64"; \
-        export OPENSSL_LIB_DIR="/usr/local/lib64"; \
-    fi && \
+RUN export ARCH="x86_64"; \
+    export OPENSSL_LIB_DIR="/usr/local/${ARCH}/lib"; \
+    export OPENSSL_DIR="/usr/local/${ARCH}"; \
     cargo zigbuild --release --target ${ARCH}-unknown-linux-musl --color never --features single-binary && \
     rm -r /tmp/target/${ARCH}-unknown-linux-musl/release/.fingerprint/cli-*
+RUN export ARCH="aarch64"; \
+    export OPENSSL_LIB_DIR="/usr/local/${ARCH}/lib"; \
+    export OPENSSL_DIR="/usr/local/${ARCH}"; \
+    cargo zigbuild --release --target ${ARCH}-unknown-linux-musl --color never --features single-binary && \
+    rm -r /tmp/target/${ARCH}-unknown-linux-musl/release/.fingerprint/cli-*
+# install dependent cli
+RUN apt update && apt install -y git

--- a/tools/docker/Dockerfile.builder
+++ b/tools/docker/Dockerfile.builder
@@ -12,7 +12,6 @@ RUN if [ "${BUILDPLATFORM}" = "arm64" ]; then export ARCH="aarch64"; else export
 FROM --platform=${BUILDPLATFORM} debian:bookworm-slim as builder-x86_64
 COPY --from=zig /opt/zig/zig /usr/local/bin/zig
 COPY --from=zig /opt/zig/lib /usr/local/bin/lib
-RUN ls -al /usr/local/bin
 RUN apt update && apt install -y curl perl make
 ENV OPENSSL_VERSION="3.2.1" ARCH="x86_64"
 RUN curl -L https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz \
@@ -24,7 +23,6 @@ RUN curl -L https://github.com/openssl/openssl/releases/download/openssl-${OPENS
 FROM --platform=${BUILDPLATFORM} debian:bookworm-slim as builder-aarch64
 COPY --from=zig /opt/zig/zig /usr/local/bin/zig
 COPY --from=zig /opt/zig/lib /usr/local/bin/lib
-RUN ls -al /usr/local/bin
 RUN apt update && apt install -y curl perl make
 ENV OPENSSL_VERSION="3.2.1" ARCH="aarch64"
 RUN curl -L https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz \

--- a/tools/scripts/merge_manifests.sh
+++ b/tools/scripts/merge_manifests.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+base="${1:-"ghcr.io/suntomi/deplo:builder"}"
+
+echo ${SUNTOMI_VCS_ACCOUNT_KEY} | docker login ghcr.io -u ${SUNTOMI_VCS_ACCOUNT} --password-stdin
+
+# create manifest if not exists
+set +e
+docker manifest inspect ${base} > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    docker manifest create ${base} ${base}-amd64 ${base}-arm64
+fi
+set -e
+# add architecture information to manifest
+docker manifest annotate ${base} ${base}-amd64 --os linux --arch amd64
+docker manifest annotate ${base} ${base}-arm64 --os linux --arch arm64
+
+# push manifest
+docker manifest push ${base}

--- a/tools/scripts/merge_manifests.sh
+++ b/tools/scripts/merge_manifests.sh
@@ -5,13 +5,9 @@ base="${1:-"ghcr.io/suntomi/deplo:builder"}"
 
 echo ${SUNTOMI_VCS_ACCOUNT_KEY} | docker login ghcr.io -u ${SUNTOMI_VCS_ACCOUNT} --password-stdin
 
-# create manifest if not exists
-set +e
-docker manifest inspect ${base} > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-    docker manifest create ${base} ${base}-amd64 ${base}-arm64
-fi
-set -e
+# create manifest list
+docker manifest create ${base} ${base}-amd64 ${base}-arm64
+
 # add architecture information to manifest
 docker manifest annotate ${base} ${base}-amd64 --os linux --arch amd64
 docker manifest annotate ${base} ${base}-arm64 --os linux --arch arm64


### PR DESCRIPTION
it takes around 90min to build current ghcr.io/suntomi/deplo:builder, because we need both platform(linux/amd64, linux/arm64) to build linux version of deplo for each architecture (linux/amd64 for amd64 version of it and arm64 is same), and build arm64 image on amd64 github action runner is tooooo slow.
I change builder image can be generate both arm64/amd64 binary by builder image of both platform(linux/amd64, linux/arm64), it should achieve significant speed up both local build and CI 👍 