### PR TITLE
Umegaya/improve debugger runs

### DIFF
--- a/.github/workflows/deplo-main.yml
+++ b/.github/workflows/deplo-main.yml
@@ -56,7 +56,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -64,7 +64,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -106,7 +106,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -114,7 +114,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: false
@@ -150,7 +150,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -158,7 +158,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -194,7 +194,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -202,7 +202,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -238,7 +238,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -246,7 +246,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -282,7 +282,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -290,7 +290,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -327,7 +327,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -335,7 +335,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -372,7 +372,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -380,7 +380,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -390,7 +390,7 @@ jobs:
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
       - name: Cache cargo
         id: deplo-cache-cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             target
@@ -432,7 +432,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -440,7 +440,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -477,7 +477,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -485,7 +485,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -521,7 +521,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -529,7 +529,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -565,7 +565,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -573,7 +573,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -609,7 +609,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -617,7 +617,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -656,7 +656,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -664,7 +664,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -674,7 +674,7 @@ jobs:
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
       - name: Cache cargo
         id: deplo-cache-cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             target
@@ -716,7 +716,7 @@ jobs:
         shell: bash
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -724,7 +724,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -734,7 +734,7 @@ jobs:
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
       - name: Cache cargo
         id: deplo-cache-cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             target

--- a/.github/workflows/deplo-main.yml
+++ b/.github/workflows/deplo-main.yml
@@ -24,6 +24,7 @@ env:
   DEPLO_GHACTION_WORKFLOW_NAME: ${{ github.workflow }}
   DEPLO_OVERWRITE_EXEC_OPTIONS: ${{ github.event.inputs.exec }}
   DEPLO_CI_START_DEBUG_DEFAULT: ${{ vars.DEPLO_CI_START_DEBUG_DEFAULT }}
+  DEPLO_CI_RUN_DEBUGGER: "true"
   SUNTOMI_AWS_ROLE: ${{ secrets.SUNTOMI_AWS_ROLE }}
   SUNTOMI_VCS_ACCOUNT: ${{ secrets.SUNTOMI_VCS_ACCOUNT }}
   SUNTOMI_VCS_ACCOUNT_EMAIL: ${{ secrets.SUNTOMI_VCS_ACCOUNT_EMAIL }}
@@ -75,7 +76,7 @@ jobs:
         id: deplo-main
         run: deplo boot
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -126,7 +127,7 @@ jobs:
         id: deplo-halt
         run: deplo halt
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -170,7 +171,7 @@ jobs:
         id: deplo-job-base
         run: deplo run base
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -214,7 +215,7 @@ jobs:
         id: deplo-job-builder
         run: deplo run builder
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -258,7 +259,7 @@ jobs:
         id: deplo-job-config
         run: deplo run config
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -302,7 +303,7 @@ jobs:
         id: deplo-job-dispatched
         run: deplo run dispatched
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -347,7 +348,7 @@ jobs:
         id: deplo-job-latest
         run: deplo run latest
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -408,7 +409,7 @@ jobs:
         id: deplo-job-mac
         run: deplo run mac
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -452,7 +453,7 @@ jobs:
         id: deplo-job-module_test
         run: deplo run module_test
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -497,7 +498,7 @@ jobs:
         id: deplo-job-product
         run: deplo run product
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -541,7 +542,7 @@ jobs:
         id: deplo-job-remote-test
         run: deplo run remote-test
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -585,7 +586,7 @@ jobs:
         id: deplo-job-repository
         run: deplo run repository
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -629,7 +630,7 @@ jobs:
         id: deplo-job-taglab
         run: deplo run taglab
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -690,7 +691,7 @@ jobs:
         id: deplo-job-test
         run: deplo run test
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -753,7 +754,7 @@ jobs:
         run: deplo run win
         shell: bash
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true

--- a/.github/workflows/deplo-manual-dispatch.yml
+++ b/.github/workflows/deplo-manual-dispatch.yml
@@ -22,6 +22,7 @@ env:
   DEPLO_GHACTION_WORKFLOW_NAME: ${{ github.workflow }}
   DEPLO_OVERWRITE_EXEC_OPTIONS: ${{ github.event.inputs.exec }}
   DEPLO_CI_START_DEBUG_DEFAULT: ${{ vars.DEPLO_CI_START_DEBUG_DEFAULT }}
+  DEPLO_CI_RUN_DEBUGGER: "true"
   SUNTOMI_AWS_ROLE: ${{ secrets.SUNTOMI_AWS_ROLE }}
   SUNTOMI_VCS_ACCOUNT: ${{ secrets.SUNTOMI_VCS_ACCOUNT }}
   SUNTOMI_VCS_ACCOUNT_EMAIL: ${{ secrets.SUNTOMI_VCS_ACCOUNT_EMAIL }}
@@ -73,7 +74,7 @@ jobs:
         id: deplo-main
         run: deplo boot
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -124,7 +125,7 @@ jobs:
         id: deplo-halt
         run: deplo halt
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -168,7 +169,7 @@ jobs:
         id: deplo-job-base
         run: deplo run base
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -212,7 +213,7 @@ jobs:
         id: deplo-job-builder
         run: deplo run builder
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -256,7 +257,7 @@ jobs:
         id: deplo-job-config
         run: deplo run config
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -300,7 +301,7 @@ jobs:
         id: deplo-job-dispatched
         run: deplo run dispatched
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -345,7 +346,7 @@ jobs:
         id: deplo-job-latest
         run: deplo run latest
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -406,7 +407,7 @@ jobs:
         id: deplo-job-mac
         run: deplo run mac
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -450,7 +451,7 @@ jobs:
         id: deplo-job-module_test
         run: deplo run module_test
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -495,7 +496,7 @@ jobs:
         id: deplo-job-product
         run: deplo run product
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -539,7 +540,7 @@ jobs:
         id: deplo-job-remote-test
         run: deplo run remote-test
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -583,7 +584,7 @@ jobs:
         id: deplo-job-repository
         run: deplo run repository
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -627,7 +628,7 @@ jobs:
         id: deplo-job-taglab
         run: deplo run taglab
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -688,7 +689,7 @@ jobs:
         id: deplo-job-test
         run: deplo run test
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -751,7 +752,7 @@ jobs:
         run: deplo run win
         shell: bash
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true

--- a/.github/workflows/deplo-manual-dispatch.yml
+++ b/.github/workflows/deplo-manual-dispatch.yml
@@ -54,7 +54,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -62,7 +62,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -104,7 +104,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -112,7 +112,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: false
@@ -148,7 +148,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -156,7 +156,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -192,7 +192,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -200,7 +200,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -236,7 +236,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -244,7 +244,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -280,7 +280,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -288,7 +288,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -325,7 +325,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -333,7 +333,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -370,7 +370,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -378,7 +378,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -388,7 +388,7 @@ jobs:
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
       - name: Cache cargo
         id: deplo-cache-cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             target
@@ -430,7 +430,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -438,7 +438,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -475,7 +475,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -483,7 +483,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -519,7 +519,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -527,7 +527,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -563,7 +563,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -571,7 +571,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -607,7 +607,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -615,7 +615,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -654,7 +654,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -662,7 +662,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -672,7 +672,7 @@ jobs:
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
       - name: Cache cargo
         id: deplo-cache-cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             target
@@ -714,7 +714,7 @@ jobs:
         shell: bash
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -722,7 +722,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -732,7 +732,7 @@ jobs:
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
       - name: Cache cargo
         id: deplo-cache-cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             target

--- a/.github/workflows/deplo-system.yml
+++ b/.github/workflows/deplo-system.yml
@@ -71,7 +71,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -79,7 +79,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -121,7 +121,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -129,7 +129,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: false
@@ -165,7 +165,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -173,7 +173,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -209,7 +209,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -217,7 +217,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -253,7 +253,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -261,7 +261,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -297,7 +297,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -305,7 +305,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -342,7 +342,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -350,7 +350,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -387,7 +387,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -395,7 +395,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -405,7 +405,7 @@ jobs:
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
       - name: Cache cargo
         id: deplo-cache-cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             target
@@ -447,7 +447,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -455,7 +455,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -492,7 +492,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -500,7 +500,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -536,7 +536,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -544,7 +544,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -580,7 +580,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -588,7 +588,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -624,7 +624,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -632,7 +632,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -671,7 +671,7 @@ jobs:
           chmod +x /usr/local/bin/deplo
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -679,7 +679,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -689,7 +689,7 @@ jobs:
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
       - name: Cache cargo
         id: deplo-cache-cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             target
@@ -731,7 +731,7 @@ jobs:
         shell: bash
       - name: Fetch repository cache
         id: fetch-repository-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .git
           key: deplo-git-v1-40BFB0C55D506BC4-${{ github.sha }}
@@ -739,7 +739,7 @@ jobs:
             deplo-git-v1-40BFB0C55D506BC4-
       - name: Checkout
         if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
@@ -749,7 +749,7 @@ jobs:
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
       - name: Cache cargo
         id: deplo-cache-cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             target

--- a/.github/workflows/deplo-system.yml
+++ b/.github/workflows/deplo-system.yml
@@ -39,6 +39,7 @@ env:
   DEPLO_GHACTION_WORKFLOW_NAME: ${{ github.workflow }}
   DEPLO_OVERWRITE_EXEC_OPTIONS: ${{ github.event.inputs.exec }}
   DEPLO_CI_START_DEBUG_DEFAULT: ${{ vars.DEPLO_CI_START_DEBUG_DEFAULT }}
+  DEPLO_CI_RUN_DEBUGGER: "true"
   SUNTOMI_AWS_ROLE: ${{ secrets.SUNTOMI_AWS_ROLE }}
   SUNTOMI_VCS_ACCOUNT: ${{ secrets.SUNTOMI_VCS_ACCOUNT }}
   SUNTOMI_VCS_ACCOUNT_EMAIL: ${{ secrets.SUNTOMI_VCS_ACCOUNT_EMAIL }}
@@ -90,7 +91,7 @@ jobs:
         id: deplo-main
         run: deplo boot
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -141,7 +142,7 @@ jobs:
         id: deplo-halt
         run: deplo halt
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -185,7 +186,7 @@ jobs:
         id: deplo-job-base
         run: deplo run base
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -229,7 +230,7 @@ jobs:
         id: deplo-job-builder
         run: deplo run builder
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -273,7 +274,7 @@ jobs:
         id: deplo-job-config
         run: deplo run config
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -317,7 +318,7 @@ jobs:
         id: deplo-job-dispatched
         run: deplo run dispatched
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -362,7 +363,7 @@ jobs:
         id: deplo-job-latest
         run: deplo run latest
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -423,7 +424,7 @@ jobs:
         id: deplo-job-mac
         run: deplo run mac
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -467,7 +468,7 @@ jobs:
         id: deplo-job-module_test
         run: deplo run module_test
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -512,7 +513,7 @@ jobs:
         id: deplo-job-product
         run: deplo run product
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -556,7 +557,7 @@ jobs:
         id: deplo-job-remote-test
         run: deplo run remote-test
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -600,7 +601,7 @@ jobs:
         id: deplo-job-repository
         run: deplo run repository
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -644,7 +645,7 @@ jobs:
         id: deplo-job-taglab
         run: deplo run taglab
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -705,7 +706,7 @@ jobs:
         id: deplo-job-test
         run: deplo run test
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true
@@ -768,7 +769,7 @@ jobs:
         run: deplo run win
         shell: bash
       - name: Setup ssh session to debug
-        if: always() && (env.DEPLO_RUN_DEBUGGER != '')
+        if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
         uses: mxschmitt/action-tmate@v3
         with:
           sudo: true

--- a/core/res/ci/ghaction/cache.yml.tmpl
+++ b/core/res/ci/ghaction/cache.yml.tmpl
@@ -1,6 +1,6 @@
 - name: Cache {name}
   id: deplo-cache-{name}
-  uses: actions/cache@v2
+  uses: actions/cache@v4
   with:
     path: |
 {paths:>6}

--- a/core/res/ci/ghaction/cached_checkout.yml.tmpl
+++ b/core/res/ci/ghaction/cached_checkout.yml.tmpl
@@ -1,6 +1,6 @@
 - name: Fetch repository cache
   id: fetch-repository-cache
-  uses: actions/cache@v2
+  uses: actions/cache@v4
   with:
     path: .git
     key: deplo-git-v1{opts_hash}-${{{{ github.sha }}}}
@@ -8,7 +8,7 @@
       deplo-git-v1{opts_hash}-
 - name: Checkout
   if: steps.fetch-repository-cache.outputs.cache-hit != 'true'
-  uses: actions/checkout@v3
+  uses: actions/checkout@v4
 {checkout_opts:>2}
 - name: Restore repository from cache
   if: steps.fetch-repository-cache.outputs.cache-hit == 'true'

--- a/core/res/ci/ghaction/checkout.yml.tmpl
+++ b/core/res/ci/ghaction/checkout.yml.tmpl
@@ -1,3 +1,3 @@
 - name: Checkout
-  uses: actions/checkout@v3
+  uses: actions/checkout@v4
 {checkout_opts:>2}

--- a/core/res/ci/ghaction/main.yml.tmpl
+++ b/core/res/ci/ghaction/main.yml.tmpl
@@ -10,6 +10,7 @@ env:
   DEPLO_GHACTION_WORKFLOW_NAME: ${{{{ github.workflow }}}}
   DEPLO_OVERWRITE_EXEC_OPTIONS: ${{{{ github.event.inputs.exec }}}}
   DEPLO_CI_START_DEBUG_DEFAULT: ${{{{ vars.DEPLO_CI_START_DEBUG_DEFAULT }}}}
+  DEPLO_CI_RUN_DEBUGGER: "true"
 {secrets:>2}
 jobs:
   deplo-main:

--- a/core/src/args/clap.rs
+++ b/core/src/args/clap.rs
@@ -113,7 +113,7 @@ fn workflow_command_options(
         .required(false)
         .takes_value(true))
     .arg(Arg::new("revision")
-        .help("git ref to run the job")
+        .help("git ref or sha to run the job")
         .long("rev")
         .takes_value(true)
         .required(false))

--- a/core/src/args/clap.rs
+++ b/core/src/args/clap.rs
@@ -132,6 +132,13 @@ there are 3 options.
         .takes_value(true)
         .possible_values(&["always", "failure", "never", "a", "f", "n"])
         .required(false))
+    .arg(Arg::new("debug-job")
+        .help(r#"if set, run debugger after finishing job only that specified in the argment. 
+normally job name. if you want to stop only on deplo boot or halt, specify like deplo-boot/deplo-halt"#)
+        .short('j')
+        .long("debug-job")
+        .takes_value(true)
+        .required(false))
 }
 fn run_command_options(
     name: &'static str,

--- a/core/src/args/clap.rs
+++ b/core/src/args/clap.rs
@@ -133,8 +133,9 @@ there are 3 options.
         .possible_values(&["always", "failure", "never", "a", "f", "n"])
         .required(false))
     .arg(Arg::new("debug-job")
-        .help(r#"if set, run debugger after finishing job only that specified in the argment. 
-normally job name. if you want to stop only on deplo boot or halt, specify like deplo-boot/deplo-halt"#)
+        .help(r#"by default, deplo try to stop on all job which matches condition specified with --debug option, except deplo-main/deplo-halt.
+if the option is set, deplo run debugger after finishing job only that specified as value.
+normally job name. if you want to debug deplo-main/deplo-halt, specify these names for the argument"#)
         .short('j')
         .long("debug-job")
         .takes_value(true)

--- a/core/src/ci/ghaction.rs
+++ b/core/src/ci/ghaction.rs
@@ -1067,11 +1067,15 @@ impl<S: shell::Shell> ci::CI for GhAction<S> {
                 "ref": "{remote_ref}",
                 "inputs": {inputs}
             }}"#, 
-                remote_ref = match config.modules.vcs().search_remote_ref(&commit)? {
-                    Some(v) => v,
-                    None => return escalate!(Box::new(ci::CIError {
-                        cause: format!("remote ref for {} not found", commit),
-                    }))
+                remote_ref = if commit.starts_with("refs") {
+                    commit
+                } else {
+                    match config.modules.vcs().search_remote_ref(&commit)? {
+                        Some(v) => v,
+                        None => return escalate!(Box::new(ci::CIError {
+                            cause: format!("remote ref for {} not found", commit),
+                        }))
+                    }
                 },
                 inputs = serde_json::to_string(&inputs)?
             )

--- a/core/src/ci/ghaction.rs
+++ b/core/src/ci/ghaction.rs
@@ -401,7 +401,7 @@ impl<S: shell::Shell> GhAction<S> {
             condition = if always {
                 ""
             } else {
-                "if: always() && (env.DEPLO_RUN_DEBUGGER != '')"
+                "if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')"
             }
         ).split("\n").map(|s| s.to_string()).collect()        
     }

--- a/core/src/config/job.rs
+++ b/core/src/config/job.rs
@@ -555,14 +555,16 @@ impl Job {
     ) -> Result<Option<String>, Box<dyn Error>> where S: shell::Shell {
         let runner = runner::Runner::new(self, config);
         let r = runner.run(shell, runtime_workflow_config);
-        if runtime_workflow_config.exec.debug.should_start(r.is_err()) {
-            log::info!("start debugger for job {} by result {:?}, config {}",
-                self.name, r, runtime_workflow_config.exec.debug);
-            let ci = self.ci(config);
-            ci.set_job_env(hashmap!{
-                "DEPLO_RUN_DEBUGGER" => "true"
-            })?;
-        }
+        crate::util::try_debug!(self.name, self.ci(config), runtime_workflow_config.exec.debug, r.is_err());
+        // if runtime_workflow_config.exec.debug.should_start(r.is_err()) {
+        //     log::info!("start debugger for job {} by result {:?}, config {}",
+        //         self.name, r, runtime_workflow_config.exec.debug);
+        // } else {
+        //     let ci = self.ci(config);
+        //     ci.set_job_env(hashmap!{
+        //         "DEPLO_CI_RUN_DEBUGGER" => ""
+        //     })?;
+        // }
         r
     }
     pub fn env(
@@ -956,6 +958,7 @@ impl Jobs {
                 }
             }
         }
+        crate::util::try_debug!("halt", config.modules.ci_by_default(), runtime_workflow_config.exec.debug, false);
         Ok(())
     }    
     fn wait_job(
@@ -1053,6 +1056,7 @@ impl Jobs {
             }
             Ok(())
         })?;
+        crate::util::try_debug!("boot", ci, runtime_workflow_config.exec.debug, false);
         if !config::Config::is_running_on_ci() {
             log::debug!("if not running on CI, all jobs should be finished");
             self.halt(config, runtime_workflow_config)?;

--- a/core/src/config/job.rs
+++ b/core/src/config/job.rs
@@ -555,7 +555,7 @@ impl Job {
     ) -> Result<Option<String>, Box<dyn Error>> where S: shell::Shell {
         let runner = runner::Runner::new(self, config);
         let r = runner.run(shell, runtime_workflow_config);
-        crate::util::try_debug!(self.name, self.ci(config), runtime_workflow_config.exec.debug, r.is_err());
+        crate::util::try_debug!(&self.name, self.ci(config), runtime_workflow_config.exec, r.is_err());
         // if runtime_workflow_config.exec.debug.should_start(r.is_err()) {
         //     log::info!("start debugger for job {} by result {:?}, config {}",
         //         self.name, r, runtime_workflow_config.exec.debug);
@@ -958,7 +958,7 @@ impl Jobs {
                 }
             }
         }
-        crate::util::try_debug!("halt", config.modules.ci_by_default(), runtime_workflow_config.exec.debug, false);
+        crate::util::try_debug!("deplo-halt", config.modules.ci_by_default(), runtime_workflow_config.exec, false);
         Ok(())
     }    
     fn wait_job(
@@ -1056,7 +1056,7 @@ impl Jobs {
             }
             Ok(())
         })?;
-        crate::util::try_debug!("boot", ci, runtime_workflow_config.exec.debug, false);
+        crate::util::try_debug!("deplo-boot", ci, runtime_workflow_config.exec, false);
         if !config::Config::is_running_on_ci() {
             log::debug!("if not running on CI, all jobs should be finished");
             self.halt(config, runtime_workflow_config)?;

--- a/core/src/config/runtime.rs
+++ b/core/src/config/runtime.rs
@@ -145,7 +145,7 @@ impl ExecOptions {
             },
             None => self.debug.clone()
         };
-        self.debug_job = match args.value_of("debug_job") {
+        self.debug_job = match args.value_of("debug-job") {
             Some(v) => Some(v.to_string()),
             None => self.debug_job.clone()
         };
@@ -171,9 +171,13 @@ impl ExecOptions {
     }
     pub fn debug_should_start(&self, job: &str, job_failure: bool) -> bool {
         if self.debug.should_start(job_failure) {
-            match &self.debug_job {
-                Some(j) => return j == job,
-                None => {}
+            return match &self.debug_job {
+                Some(j) => j == job,
+                None => match job {
+                    // if debug_job is not specified, deplo-boot/deplo-halt is ignored.
+                    "deplo-boot"| "deplo-halt" => job_failure,
+                    _ => true
+                }
             }
         }
         return false;

--- a/core/src/config/runtime.rs
+++ b/core/src/config/runtime.rs
@@ -81,6 +81,7 @@ pub struct ExecOptions {
     pub revision: Option<String>,
     pub release_target: Option<String>,
     pub debug: StartDebugOn,
+    pub debug_job: Option<String>,
     pub verbosity: u64,
     pub remote: bool,
     pub follow_dependency: bool,
@@ -94,6 +95,7 @@ impl ExecOptions {
             revision: None,
             release_target: None,
             debug: StartDebugOn::Default,
+            debug_job: None,
             verbosity: 0,
             remote: false,
             follow_dependency: false,
@@ -143,6 +145,10 @@ impl ExecOptions {
             },
             None => self.debug.clone()
         };
+        self.debug_job = match args.value_of("debug_job") {
+            Some(v) => Some(v.to_string()),
+            None => self.debug_job.clone()
+        };
         self.timeout = match args.value_of("timeout") {
             Some(v) => Some(v.parse().expect(
                 &format!("value of `timeout` should be a number but {}", v)
@@ -162,6 +168,15 @@ impl ExecOptions {
         if args.occurence_of("silent") > 0 {
             self.silent = true;
         }
+    }
+    pub fn debug_should_start(&self, job: &str, job_failure: bool) -> bool {
+        if self.debug.should_start(job_failure) {
+            match &self.debug_job {
+                Some(j) => return j == job,
+                None => {}
+            }
+        }
+        return false;
     }
 }
 

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -468,9 +468,9 @@ pub fn join_vector<T>(src: Vec<Vec<T>>) -> Vec<T> {
 #[macro_export]
 macro_rules! macro_try_debug {
     ($ctx: expr, $ci: expr, $config: expr, $failure: expr) => {
-        if $config.should_start($failure) {
-            log::info!("start debugger for job {} by failure {:?}, config {}",
-                $ctx, $failure, $config);
+        if $config.debug_should_start($ctx, $failure) {
+            log::info!("start debugger for job {} by failure {}, config {}:{:?}",
+                $ctx, $failure, $config.debug, $config.debug_job);
         } else {
             $ci.set_job_env(hashmap!{
                 "DEPLO_CI_RUN_DEBUGGER" => ""

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -464,6 +464,23 @@ pub fn join_vector<T>(src: Vec<Vec<T>>) -> Vec<T> {
     r
 }
 
+// debugger
+#[macro_export]
+macro_rules! macro_try_debug {
+    ($ctx: expr, $ci: expr, $config: expr, $failure: expr) => {
+        if $config.should_start($failure) {
+            log::info!("start debugger for job {} by failure {:?}, config {}",
+                $ctx, $failure, $config);
+        } else {
+            $ci.set_job_env(hashmap!{
+                "DEPLO_CI_RUN_DEBUGGER" => ""
+            })?;
+        }        
+    }
+}
+pub use macro_try_debug as try_debug;
+
+
 // json
 // same as serde_json::from_str, but support the case that s represents single number/boolean/null.
 // serde_json::from_str does not seem to support them.

--- a/tools/scripts/setup_release_env.sh
+++ b/tools/scripts/setup_release_env.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "DEPLO_CI_RELEASE_TARGET = [${DEPLO_CI_RELEASE_TARGET}]"
+
 if [ "${DEPLO_CI_RELEASE_TARGET}" = "prod" ]; then
     export DEPLO_RELEASE_TAG=${DEPLO_CI_TAG_NAME}
     export DEPLO_RELEASE_NAME=${DEPLO_CI_TAG_NAME}


### PR DESCRIPTION
improvement of previous pr #103 

- can specify refspec directly as --rev parameter (previously it only accepts commit hash)
- debugger runs even job is panic!ed
- debugger runs for deplo-boot/deplo-halt
  - but if debugger run specified always (--debug=always), it ignores deplo-boot, deplo-halt
- remove warning `using node20`