### PR TITLE
run restore cache commands explicitly on bash

### DIFF
--- a/.github/workflows/deplo-main.yml
+++ b/.github/workflows/deplo-main.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Boot deplo
         id: deplo-main
         run: deplo boot
@@ -123,6 +124,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Halt deplo
         id: deplo-halt
         run: deplo halt
@@ -166,6 +168,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: base
         id: deplo-job-base
@@ -210,6 +213,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: builder
         id: deplo-job-builder
@@ -254,6 +258,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: config
         id: deplo-job-config
@@ -298,6 +303,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: dispatched
         id: deplo-job-dispatched
@@ -343,6 +349,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: latest
         id: deplo-job-latest
@@ -388,6 +395,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Cache cargo
         id: deplo-cache-cargo
         uses: actions/cache@v4
@@ -448,6 +456,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: module_test
         id: deplo-job-module_test
@@ -493,6 +502,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: product
         id: deplo-job-product
@@ -537,6 +547,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: remote-test
         id: deplo-job-remote-test
@@ -581,6 +592,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: repository
         id: deplo-job-repository
@@ -625,6 +637,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: taglab
         id: deplo-job-taglab
@@ -672,6 +685,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Cache cargo
         id: deplo-cache-cargo
         uses: actions/cache@v4
@@ -732,6 +746,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Cache cargo
         id: deplo-cache-cargo
         uses: actions/cache@v4

--- a/.github/workflows/deplo-manual-dispatch.yml
+++ b/.github/workflows/deplo-manual-dispatch.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Boot deplo
         id: deplo-main
         run: deplo boot
@@ -121,6 +122,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Halt deplo
         id: deplo-halt
         run: deplo halt
@@ -164,6 +166,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: base
         id: deplo-job-base
@@ -208,6 +211,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: builder
         id: deplo-job-builder
@@ -252,6 +256,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: config
         id: deplo-job-config
@@ -296,6 +301,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: dispatched
         id: deplo-job-dispatched
@@ -341,6 +347,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: latest
         id: deplo-job-latest
@@ -386,6 +393,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Cache cargo
         id: deplo-cache-cargo
         uses: actions/cache@v4
@@ -446,6 +454,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: module_test
         id: deplo-job-module_test
@@ -491,6 +500,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: product
         id: deplo-job-product
@@ -535,6 +545,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: remote-test
         id: deplo-job-remote-test
@@ -579,6 +590,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: repository
         id: deplo-job-repository
@@ -623,6 +635,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: taglab
         id: deplo-job-taglab
@@ -670,6 +683,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Cache cargo
         id: deplo-cache-cargo
         uses: actions/cache@v4
@@ -730,6 +744,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Cache cargo
         id: deplo-cache-cargo
         uses: actions/cache@v4

--- a/.github/workflows/deplo-system.yml
+++ b/.github/workflows/deplo-system.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Boot deplo
         id: deplo-main
         run: deplo boot
@@ -138,6 +139,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Halt deplo
         id: deplo-halt
         run: deplo halt
@@ -181,6 +183,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: base
         id: deplo-job-base
@@ -225,6 +228,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: builder
         id: deplo-job-builder
@@ -269,6 +273,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: config
         id: deplo-job-config
@@ -313,6 +318,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: dispatched
         id: deplo-job-dispatched
@@ -358,6 +364,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: latest
         id: deplo-job-latest
@@ -403,6 +410,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Cache cargo
         id: deplo-cache-cargo
         uses: actions/cache@v4
@@ -463,6 +471,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: module_test
         id: deplo-job-module_test
@@ -508,6 +517,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: product
         id: deplo-job-product
@@ -552,6 +562,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: remote-test
         id: deplo-job-remote-test
@@ -596,6 +607,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: repository
         id: deplo-job-repository
@@ -640,6 +652,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
   
       - name: taglab
         id: deplo-job-taglab
@@ -687,6 +700,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Cache cargo
         id: deplo-cache-cargo
         uses: actions/cache@v4
@@ -747,6 +761,7 @@ jobs:
       - name: Restore repository from cache
         if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
         run: git reset --hard HEAD && git submodule update --init --recursive && deplo -v=1 ci restore-cache --submodules
+        shell: bash
       - name: Cache cargo
         id: deplo-cache-cargo
         uses: actions/cache@v4

--- a/core/res/ci/ghaction/cached_checkout.yml.tmpl
+++ b/core/res/ci/ghaction/cached_checkout.yml.tmpl
@@ -13,3 +13,4 @@
 - name: Restore repository from cache
   if: steps.fetch-repository-cache.outputs.cache-hit == 'true'
   run: {restore_commands}
+  shell: bash


### PR DESCRIPTION
because windows runner silently ignores deplo ci restore-cache invocation. 

see https://github.com/suntomi/deplo/actions/runs/8368493039/job/22912762181#step:5:30 for windows runner job.
it should be like https://github.com/suntomi/deplo/actions/runs/8368493039/job/22912754240#step:5:242 (contains `deplo ci restore-cache` output), actually, necessary restore does not occur. 

explicitly specify shell (bash) solve the problem, like below.

https://github.com/suntomi/deplo/actions/runs/8368594786/job/22913011396#step:5:244
