### PR TITLE
use host deplo cli to upload symbol files

### DIFF
--- a/tools/docker/.gitignore
+++ b/tools/docker/.gitignore
@@ -1,2 +1,3 @@
 bin
 manifests
+deplo

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -11,6 +11,7 @@ ADD ./Deplo.toml /workdir/
 ADD ./tools/modules /workdir/tools/modules
 ADD ./.deplo/env /workdir/.env
 ADD ./.git /workdir/.git
+ADD ./tools/docker/bin/host-deplo /usr/local/bin/host-deplo
 RUN echo "DEPLO_RELEASE_VERSION=[${DEPLO_RELEASE_VERSION}]"
 RUN if [ "${TARGETARCH}" = "arm64" ]; then export ARCH="aarch64"; else export ARCH="x86_64"; fi && \
     cargo zigbuild --release --target=${ARCH}-unknown-linux-musl && \
@@ -21,7 +22,7 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then export ARCH="aarch64"; else export AR
     ${ARCH}-linux-gnu-strip /tmp/cli && \
     ls -al /tmp/cli && \
     CI=true GITHUB_OUTPUT=true GITHUB_ENV=true \
-        /tmp/cli vcs release-assets ${DEPLO_RELEASE_VERSION} \
+        /usr/local/bin/host-deplo vcs release-assets ${DEPLO_RELEASE_VERSION} \
         /tmp/cli.debug --replace -o name=deplo-Linux-${ARCH}.debug
 
 FROM ghcr.io/suntomi/deplo:base

--- a/tools/scripts/build_linux.sh
+++ b/tools/scripts/build_linux.sh
@@ -13,10 +13,12 @@ export_bin() {
     docker rm deplo-bin
 }
 
+cp $(which deplo) ${ROOT}/tools/docker/bin/host-deplo
 deplo ci getenv --out=${ROOT}/.deplo/env
 echo ${SUNTOMI_VCS_ACCOUNT_KEY} | docker login ghcr.io -u ${SUNTOMI_VCS_ACCOUNT} --password-stdin
 docker buildx create --name mp --bootstrap --use
-docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg DEPLO_RELEASE_VERSION=${DEPLO_RELEASE_VERSION} \
+docker buildx build --push --platform linux/amd64,linux/arm64 \
+    --build-arg DEPLO_RELEASE_VERSION=${DEPLO_RELEASE_VERSION} \
     -t ghcr.io/suntomi/deplo:${DEPLO_RELEASE_VERSION} -f ${ROOT}/tools/docker/Dockerfile ${ROOT}
 export_bin amd64 ${ROOT}/tools/docker/bin/x86_64
 export_bin arm64 ${ROOT}/tools/docker/bin/aarch64


### PR DESCRIPTION
generally, cli which is built with different architecture than host will not be work even in container running in the host (as long as not using proper emulation feature like qemu). but even if we do so that will lead slower execution. so we just copy host's deplo cli and use it in image build process