### PR TITLE
add schema type for generated dispatch inputs

### DIFF
--- a/.github/workflows/deplo-manual-dispatch.yml
+++ b/.github/workflows/deplo-manual-dispatch.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       target:
         required: true
-        default: dev
+        default: "dev"
         type: choice
         options:
           - stage
@@ -14,6 +14,19 @@ on:
           - prod
           - qa
           - review
+      param2:
+        required: true
+        default: 3.14
+        type: number
+      param3:
+        required: true
+        default: "fuga"
+      param4:
+        default: false
+        type: boolean
+      param1:
+        default: 100
+        type: number
 
 env:
   DEPLO_GHACTION_CI_ID: ${{ github.run_id }}-${{ github.run_attempt }}

--- a/Deplo.toml
+++ b/Deplo.toml
@@ -119,6 +119,24 @@ manual_dispatch = {
                 "review"
             ]
         }
+        param1 = {
+            type = "number"
+            default = 100
+        }
+        param2 = {
+            required = true
+            type = "float"
+            default = 3.14
+        }
+        param3 = {
+            required = true
+            type = "string"
+            default = "fuga"
+        }
+        param4 = {
+            type = "bool"
+            default = false
+        }
     }    
 }
 slack = {

--- a/core/src/ci/ghaction.rs
+++ b/core/src/ci/ghaction.rs
@@ -184,11 +184,13 @@ impl<S: shell::Shell> GhAction<S> {
                 options.push(format!("required: {}", schema.required.unwrap()));
             }
             if schema.default.is_some() {
-                options.push(format!("default: {}", schema.default.as_ref().unwrap()));
+                options.push(format!("default: {}", schema.default.as_ref().unwrap().to_string()));
             }
             match &schema.class {
                 config::workflow::InputSchemaClass::Value{ty,..} => match ty {
                     config::workflow::InputValueType::Bool => options.push(format!("type: boolean")),
+                    config::workflow::InputValueType::Number => options.push(format!("type: number")),
+                    config::workflow::InputValueType::Float => options.push(format!("type: number")),
                     _ => {},
                 },
                 config::workflow::InputSchemaClass::Enum{options: opts} => {

--- a/core/src/config/workflow.rs
+++ b/core/src/config/workflow.rs
@@ -47,12 +47,43 @@ pub enum InputSchemaClass {
     Object{schema: HashMap<String, Box<InputSchema>>}
 }
 #[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InputDefaultValue {
+    Float(f64),
+    Number(i64),
+    String(String),
+    Bool(bool),
+}
+impl InputDefaultValue {
+    pub fn to_string(&self) -> String {
+        match self {
+            Self::Number(v) => format!("{}", v),
+            Self::Float(v) => format!("{}", v),
+            Self::String(v) => format!("\"{}\"", v),
+            Self::Bool(v) => format!("{}", v),
+        }
+    }
+}
+
+mod tests {
+    #[allow(unused_imports)]
+    use crate::config::workflow::*;
+    #[test]
+    fn test_input_default_value() {
+        let value = InputDefaultValue::Number(1);
+        match toml::to_string(&value) {
+            Ok(v) => assert_eq!(v, "1".to_string()),
+            Err(e) => panic!("{}", e)
+        }
+    }
+}
+#[derive(Serialize, Deserialize)]
 pub struct InputSchema {
     #[serde(flatten)]
     pub class: InputSchemaClass,
     pub required: Option<bool>,
     pub description: Option<String>,
-    pub default: Option<String>
+    pub default: Option<InputDefaultValue>
 }
 impl InputSchema {
     pub fn verify(&self, _inputs: &serde_json::Value) {


### PR DESCRIPTION
for manual dispatch, input schema's variable type (bool/number/float/string) was not respected from generated yaml file. 
the PR improve manual dispatch yaml generation for allowing variable types to be set as input type configuration