### PR TITLE
Umegaya/fix ci by env

### DIFF
--- a/.github/workflows/deplo-main.yml
+++ b/.github/workflows/deplo-main.yml
@@ -93,7 +93,7 @@ jobs:
         run: deplo boot
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   deplo-halt:
@@ -162,7 +162,7 @@ jobs:
         run: deplo halt
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   base:
@@ -214,7 +214,7 @@ jobs:
         run: deplo run base
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   builder:
@@ -266,7 +266,7 @@ jobs:
         run: deplo run builder
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   config:
@@ -318,7 +318,7 @@ jobs:
         run: deplo run config
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   dispatched:
@@ -370,7 +370,7 @@ jobs:
         run: deplo run dispatched
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   latest:
@@ -423,7 +423,7 @@ jobs:
         run: deplo run latest
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   mac:
@@ -491,7 +491,7 @@ jobs:
         run: deplo run mac
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   module_test:
@@ -543,7 +543,7 @@ jobs:
         run: deplo run module_test
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   prbot-test:
@@ -595,7 +595,7 @@ jobs:
         run: deplo run prbot-test
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   product:
@@ -648,7 +648,7 @@ jobs:
         run: deplo run product
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   remote-test:
@@ -700,7 +700,7 @@ jobs:
         run: deplo run remote-test
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   repository:
@@ -752,7 +752,7 @@ jobs:
         run: deplo run repository
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   taglab:
@@ -804,7 +804,7 @@ jobs:
         run: deplo run taglab
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   test:
@@ -873,7 +873,7 @@ jobs:
         run: deplo run test
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   win:
@@ -943,6 +943,6 @@ jobs:
         shell: bash
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true

--- a/.github/workflows/deplo-main.yml
+++ b/.github/workflows/deplo-main.yml
@@ -19,6 +19,7 @@ on:
     types: [created,opened,closed]
 
 env:
+  DEPLO_CI_ACCOUNT_NAME: "default"
   DEPLO_GHACTION_CI_ID: ${{ github.run_id }}-${{ github.run_attempt }}
   DEPLO_GHACTION_EVENT_DATA: ${{ toJson(github) }}
   DEPLO_GHACTION_WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/deplo-manual-dispatch.yml
+++ b/.github/workflows/deplo-manual-dispatch.yml
@@ -29,6 +29,7 @@ on:
           - review
 
 env:
+  DEPLO_CI_ACCOUNT_NAME: "default"
   DEPLO_GHACTION_CI_ID: ${{ github.run_id }}-${{ github.run_attempt }}
   DEPLO_GHACTION_EVENT_DATA: ${{ toJson(github) }}
   DEPLO_GHACTION_WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/deplo-manual-dispatch.yml
+++ b/.github/workflows/deplo-manual-dispatch.yml
@@ -103,7 +103,7 @@ jobs:
         run: deplo boot
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   deplo-halt:
@@ -172,7 +172,7 @@ jobs:
         run: deplo halt
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   base:
@@ -224,7 +224,7 @@ jobs:
         run: deplo run base
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   builder:
@@ -276,7 +276,7 @@ jobs:
         run: deplo run builder
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   config:
@@ -328,7 +328,7 @@ jobs:
         run: deplo run config
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   dispatched:
@@ -380,7 +380,7 @@ jobs:
         run: deplo run dispatched
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   latest:
@@ -433,7 +433,7 @@ jobs:
         run: deplo run latest
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   mac:
@@ -501,7 +501,7 @@ jobs:
         run: deplo run mac
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   module_test:
@@ -553,7 +553,7 @@ jobs:
         run: deplo run module_test
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   prbot-test:
@@ -605,7 +605,7 @@ jobs:
         run: deplo run prbot-test
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   product:
@@ -658,7 +658,7 @@ jobs:
         run: deplo run product
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   remote-test:
@@ -710,7 +710,7 @@ jobs:
         run: deplo run remote-test
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   repository:
@@ -762,7 +762,7 @@ jobs:
         run: deplo run repository
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   taglab:
@@ -814,7 +814,7 @@ jobs:
         run: deplo run taglab
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   test:
@@ -883,7 +883,7 @@ jobs:
         run: deplo run test
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   win:
@@ -953,6 +953,6 @@ jobs:
         shell: bash
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true

--- a/.github/workflows/deplo-system.yml
+++ b/.github/workflows/deplo-system.yml
@@ -34,6 +34,7 @@ on:
           - win
 
 env:
+  DEPLO_CI_ACCOUNT_NAME: "default"
   DEPLO_GHACTION_CI_ID: ${{ github.run_id }}-${{ github.run_attempt }}
   DEPLO_GHACTION_EVENT_DATA: ${{ toJson(github) }}
   DEPLO_GHACTION_WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/deplo-system.yml
+++ b/.github/workflows/deplo-system.yml
@@ -108,7 +108,7 @@ jobs:
         run: deplo boot
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   deplo-halt:
@@ -177,7 +177,7 @@ jobs:
         run: deplo halt
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   base:
@@ -229,7 +229,7 @@ jobs:
         run: deplo run base
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   builder:
@@ -281,7 +281,7 @@ jobs:
         run: deplo run builder
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   config:
@@ -333,7 +333,7 @@ jobs:
         run: deplo run config
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   dispatched:
@@ -385,7 +385,7 @@ jobs:
         run: deplo run dispatched
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   latest:
@@ -438,7 +438,7 @@ jobs:
         run: deplo run latest
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   mac:
@@ -506,7 +506,7 @@ jobs:
         run: deplo run mac
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   module_test:
@@ -558,7 +558,7 @@ jobs:
         run: deplo run module_test
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   prbot-test:
@@ -610,7 +610,7 @@ jobs:
         run: deplo run prbot-test
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   product:
@@ -663,7 +663,7 @@ jobs:
         run: deplo run product
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   remote-test:
@@ -715,7 +715,7 @@ jobs:
         run: deplo run remote-test
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   repository:
@@ -767,7 +767,7 @@ jobs:
         run: deplo run repository
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   taglab:
@@ -819,7 +819,7 @@ jobs:
         run: deplo run taglab
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   test:
@@ -888,7 +888,7 @@ jobs:
         run: deplo run test
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true
   win:
@@ -958,6 +958,6 @@ jobs:
         shell: bash
       - name: Setup ssh session to debug
         if: always() && (env.DEPLO_CI_RUN_DEBUGGER != '')
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
         with:
           sudo: true

--- a/.github/workflows/deplo-update.yml
+++ b/.github/workflows/deplo-update.yml
@@ -16,6 +16,7 @@ permissions:
   issues: write
 
 env:
+  DEPLO_CI_ACCOUNT_NAME: "default"
   DEPLO_GHACTION_CI_ID: ${{ github.run_id }}-${{ github.run_attempt }}
   DEPLO_GHACTION_EVENT_DATA: ${{ toJson(github) }}
   DEPLO_GHACTION_WORKFLOW_NAME: ${{ github.workflow }}

--- a/cli/src/command/ci.rs
+++ b/cli/src/command/ci.rs
@@ -19,7 +19,7 @@ pub struct CI<S: shell::Shell = shell::Default> {
 impl<S: shell::Shell> CI<S> {
     fn setenv<A: args::Args>(&self, _: &A) -> Result<(), Box<dyn Error>> {
         let config = self.config.borrow();
-        let ci = config.modules.ci_by_default();
+        let ci = config.ci_by_env();
         for (k,v) in config::secret::vars()? {
             println!("set secret {}", k);
             let targets = config::secret::targets(&k);
@@ -50,7 +50,7 @@ impl<S: shell::Shell> CI<S> {
     }
     fn token<A: args::Args>(&self, args: &A) -> Result<(), Box<dyn Error>> {
         let config = self.config.borrow();
-        let (_, ci) = config.ci_by_env();
+        let ci = config.ci_by_env();
         match args.subcommand() {
             Some(("oidc", subargs)) => {
                 let output = match subargs.value_of("output") {
@@ -81,7 +81,7 @@ impl<S: shell::Shell> CI<S> {
     }
     fn restore_cache<A: args::Args>(&self, args: &A) -> Result<(), Box<dyn Error>> {
         let config = self.config.borrow();
-        let (_, ci) = config.ci_by_env();
+        let ci = config.ci_by_env();
         ci.restore_cache(args.get_flag("submodules"))
     } 
 }

--- a/core/res/ci/ghaction/common_envs.yml.tmpl
+++ b/core/res/ci/ghaction/common_envs.yml.tmpl
@@ -1,3 +1,4 @@
+DEPLO_CI_ACCOUNT_NAME: "{account_name}"
 DEPLO_GHACTION_CI_ID: ${{{{ github.run_id }}}}-${{{{ github.run_attempt }}}}
 DEPLO_GHACTION_EVENT_DATA: ${{{{ toJson(github) }}}}
 DEPLO_GHACTION_WORKFLOW_NAME: ${{{{ github.workflow }}}}

--- a/core/src/ci.rs
+++ b/core/src/ci.rs
@@ -54,6 +54,7 @@ pub trait CI {
     fn new(
         config: &config::Container, account_name: &str
     ) -> Result<Self, Box<dyn Error>> where Self : Sized;
+    fn account_name(&self) -> &str;
     fn runs_on_service(&self) -> bool;
     fn restore_cache(&self, submodule: bool) -> Result<(), Box<dyn Error>>;
     fn generate_config(&self, reinit: bool) -> Result<(), Box<dyn Error>>;

--- a/core/src/ci/circleci.rs
+++ b/core/src/ci/circleci.rs
@@ -69,11 +69,10 @@ impl<'a, S: shell::Shell> ci::CI for CircleCI<S> {
         return &self.account_name
     }
     fn runs_on_service(&self) -> bool {
-        match std::env::var("DEPLO_CI_TYPE") {
-            Ok(v) if !v.is_empty() => return v == "CircleCI",
-            _ => {}
+        match std::env::var("DEPLO_CI_ACCOUNT_NAME") {
+            Ok(v) if !v.is_empty() => self.account_name == v,
+            _ => false,
         }
-        std::env::var("CIRCLE_SHA1").is_ok()
     }
     fn restore_cache(&self, _submodule: bool) -> Result<(), Box<dyn Error>> {
         Ok(())

--- a/core/src/ci/circleci.rs
+++ b/core/src/ci/circleci.rs
@@ -82,7 +82,7 @@ impl<'a, S: shell::Shell> ci::CI for CircleCI<S> {
         let account = config.ci.get(&self.account_name).expect(&format!("no ci config for {}", self.account_name));
         let repository_root = config.modules.vcs().repository_root()?;
         let jobs = config.jobs.as_map();
-        let create_main = config.ci.is_main(vec!["CircleCI"]);
+        let create_main = config.ci.is_main("CircleCI");
         // TODO_PATH: use Path to generate path of /.circleci/...
         let circle_yml_path = format!("{}/.circleci/config.yml", repository_root);
         fs::create_dir_all(&format!("{}/.circleci", repository_root))?;

--- a/core/src/ci/circleci.rs
+++ b/core/src/ci/circleci.rs
@@ -65,6 +65,9 @@ impl<'a, S: shell::Shell> ci::CI for CircleCI<S> {
             shell: S::new(config),
         });
     }
+    fn account_name(&self) -> &str {
+        return &self.account_name
+    }
     fn runs_on_service(&self) -> bool {
         match std::env::var("DEPLO_CI_TYPE") {
             Ok(v) if !v.is_empty() => return v == "CircleCI",

--- a/core/src/ci/ghaction.rs
+++ b/core/src/ci/ghaction.rs
@@ -33,7 +33,7 @@ lazy_static! {
     pub static ref DEPLO_GHACTION_MODULE_VERSIONS: HashMap<String, String> = hashmap! {
         "actions/checkout".to_string() => "v6".to_string(),
         "actions/cache".to_string() => "v5".to_string(),
-        "mxschmitt/action-tmate".to_string() => "c0afd6f790e3a5564914980036ebf83216678101".to_string(),
+        "mxschmitt/action-tmate".to_string() => "35b54afac29c97fb54faba5b513f8fbd1882f113".to_string(),
         "actions/create-github-app-token".to_string() => "v3".to_string()
     };
 }

--- a/core/src/ci/ghaction.rs
+++ b/core/src/ci/ghaction.rs
@@ -803,6 +803,9 @@ impl<S: shell::Shell> ci::CI for GhAction<S> {
             }
         });
     }
+    fn account_name(&self) -> &str {
+        return &self.account_name
+    }
     fn runs_on_service(&self) -> bool {
         match std::env::var("DEPLO_CI_TYPE") {
             Ok(v) if !v.is_empty() => {

--- a/core/src/ci/ghaction.rs
+++ b/core/src/ci/ghaction.rs
@@ -874,7 +874,7 @@ impl<S: shell::Shell> ci::CI for GhAction<S> {
         // TODO_PATH: use Path to generate path of /.github/...
         let main_workflow_yml_path = format!(
             "{}/.github/workflows/deplo-main{}.yml", repository_root, config_post_fix);
-        let create_main = config.ci.is_main(vec!["GhAction", "GhActionApp"]);
+        let create_main = config.ci.is_main("GhAction");
         if jobs.len() == 0 {
             log::info!(
                 "no jobs defined for the account {}. skip ghaction job config generation",
@@ -1407,11 +1407,8 @@ impl<S: shell::Shell> ci::CI for GhAction<S> {
     fn process_env(&self) -> Result<HashMap<&str, String>, Box<dyn Error>> {
         let config = self.config.borrow();
         let vcs = config.modules.vcs();
-        let ci_type = config.ci.get(&self.account_name).expect(&format!(
-            "CI account {} should exist", self.account_name
-        )).type_as_str().to_string();
         let mut envs = hashmap!{
-            "DEPLO_CI_TYPE" => ci_type,
+            "DEPLO_CI_TYPE" => "GhAction".to_string(),
         };
         if config::Config::is_running_on_ci() {
             envs.insert(config::DEPLO_RUNNING_ON_CI_ENV_KEY, "true".to_string());

--- a/core/src/ci/ghaction.rs
+++ b/core/src/ci/ghaction.rs
@@ -53,8 +53,8 @@ fn get_module_version(module: &str) -> String {
     DEPLO_GHACTION_MODULE_VERSIONS.get(module).unwrap().clone()
 }
 
-fn common_envs() -> Vec<String> {
-    format!(include_str!("../../res/ci/ghaction/common_envs.yml.tmpl"))
+fn common_envs(account_name: &str) -> Vec<String> {
+    format!(include_str!("../../res/ci/ghaction/common_envs.yml.tmpl"), account_name = account_name)
         .split("\n")
         .map(|s| s.to_string())
         .collect()
@@ -720,7 +720,7 @@ impl<S: shell::Shell> GhAction<S> {
                 include_str!("../../res/ci/ghaction/update.yml.tmpl"),
                 current_version = config::DEPLO_VERSION,
                 release_url_base = config::DEPLO_RELEASE_URL_BASE,
-                common_envs = MultilineFormatString{ strings: &common_envs(), postfix: None },
+                common_envs = MultilineFormatString{ strings: &common_envs(&self.account_name), postfix: None },
                 secrets = MultilineFormatString{ strings: secrets, postfix: None },
                 fetchcli = MultilineFormatString{
                     strings: &self.generate_fetchcli_steps(&config::job::Runner::Machine{
@@ -807,16 +807,10 @@ impl<S: shell::Shell> ci::CI for GhAction<S> {
         return &self.account_name
     }
     fn runs_on_service(&self) -> bool {
-        match std::env::var("DEPLO_CI_TYPE") {
-            Ok(v) if !v.is_empty() => {
-                let config = self.config.borrow();
-                return config.ci.get(&self.account_name).map_or(false, |account| {
-                    account.type_as_str() == v
-                });
-            },
-            _ => {}
+        match std::env::var("DEPLO_CI_ACCOUNT_NAME") {
+            Ok(v) if !v.is_empty() => self.account_name == v,
+            _ => false,
         }
-        std::env::var("GITHUB_ACTION").is_ok()
     }
     fn restore_cache(&self, submodule: bool) -> Result<(), Box<dyn Error>> {
         log::info!("restore cache: start submodule = {}", submodule);
@@ -1009,7 +1003,7 @@ impl<S: shell::Shell> ci::CI for GhAction<S> {
                         strings: &(if create_main { entrypoint } else { vec![] }),
                         postfix: None
                     },
-                    common_envs = MultilineFormatString{ strings: &common_envs(), postfix: None },
+                    common_envs = MultilineFormatString{ strings: &common_envs(&self.account_name), postfix: None },
                     secrets = MultilineFormatString{ strings: &secrets, postfix: None },
                     outputs = MultilineFormatString{ 
                         strings: &self.generate_outputs(&jobs),

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -81,10 +81,10 @@ impl Modules {
     pub fn ci_by_default(&self) -> &Box<dyn crate::ci::CI> {
         self.ci_for("default")
     }
-    pub fn ci_by_env(&self) -> Option<(&str, &Box<dyn crate::ci::CI>)> {
-        for (k, v) in &self.ci {
+    pub fn ci_by_env(&self) -> Option<&Box<dyn crate::ci::CI>> {
+        for (_k, v) in &self.ci {
             if v.runs_on_service() {
-                return Some((k, v));
+                return Some(v);
             }
         }
         return None;
@@ -245,14 +245,25 @@ impl Config {
         self.workflows.setup();
         self.jobs.setup();
     }
-    pub fn ci_by_env(&self) -> (&str, &Box<dyn crate::ci::CI>) {
+    pub fn ci_by_env<'a>(&'a self) -> &'a Box<dyn crate::ci::CI + 'a> {
+        // the cli is invoked from deplo job script: use the job name to find the ci module
+        match std::env::var("DEPLO_CI_JOB_NAME") {
+            Ok(job_name) => {
+                let job = self.jobs.as_map().get(&job_name).expect(&format!("job {} does not exist", job_name));
+                return job.ci(self);
+            },
+            Err(_) => {}
+        }
+        // otherwise, deplo invoked directly from user shell or CI service.
+        // if from CI service, detect ci type by search for specific environment variagble
         match self.modules.ci_by_env() {
             Some(v) => v,
+            // otherwise, fallback to default ci account (or use --ci option to specify)
             None => match &self.runtime.ci {
-                Some(account_name) => (account_name.as_str(), self.modules.ci_for(account_name)),
+                Some(account_name) => self.modules.ci_for(account_name),
                 None => {
-                    log::warn!("no CI service environment detected and --ci is not specified. fallback to default CI account");
-                    ("default", self.modules.ci_by_default())
+                    log::debug!("no CI service environment detected and --ci is not specified. fallback to default CI account");
+                    self.modules.ci_by_default()
                 }
             }
         }
@@ -279,7 +290,7 @@ impl Config {
         })
     }
     pub fn ci_process_envs(&self) -> Result<HashMap<String, Option<String>>, Box<dyn Error>> {
-        let (account_name, ci) = self.ci_by_env();
+        let ci = self.ci_by_env();
         let vcs = self.modules.vcs();
         let (ref_type, ref_path) = vcs.current_ref()?;
         let (may_tag, may_branch) = if ref_type == crate::vcs::RefType::Tag {
@@ -289,7 +300,7 @@ impl Config {
         };
         let commit_id = vcs.commit_hash(None)?;
         let random_id = randombytes_as_string!(16);
-        let ci_type = self.ci.get(account_name).unwrap().type_as_str().to_string();
+        let ci_type = self.ci.get(ci.account_name()).unwrap().type_as_str().to_string();
         let mut penvs = hashmap!{
             // on local, CI ID should be inherited from parent, if exists.
             // on CI DEPLO_CI_ID replaced with CI specific environment variable that represents canonical ID

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -300,7 +300,7 @@ impl Config {
         };
         let commit_id = vcs.commit_hash(None)?;
         let random_id = randombytes_as_string!(16);
-        let ci_type = self.ci.get(ci.account_name()).unwrap().type_as_str().to_string();
+        let ci_type = self.ci.get(ci.account_name()).unwrap().ci_type().to_string();
         let mut penvs = hashmap!{
             // on local, CI ID should be inherited from parent, if exists.
             // on CI DEPLO_CI_ID replaced with CI specific environment variable that represents canonical ID

--- a/core/src/config/ci.rs
+++ b/core/src/config/ci.rs
@@ -33,12 +33,20 @@ pub enum Account {
     Module(config::module::ConfigFor<crate::ci::ModuleDescription>)
 }
 impl Account {
-    pub fn type_matched(&self, t: &str) -> bool {
+    pub fn ci_type_matched(&self, t: &str) -> bool {
         match self {
             Self::Module(c) => return c.value(|v| v.uses.to_string().starts_with(t)),
             _ => {}
         }
-        return t == self.type_as_str()
+        return t == self.ci_type()
+    }
+    pub fn ci_type(&self) -> &'static str {
+        match self {
+            Self::GhAction{..} => "GhAction",
+            Self::GhActionApp{..} => "GhAction",
+            Self::CircleCI{..} => "CircleCI",
+            Self::Module{..} => "Module",
+        }
     }
     pub fn type_as_str(&self) -> &'static str {
         match self {
@@ -69,14 +77,8 @@ impl Accounts {
     pub fn default(&self) -> &Account {
         self.as_map().get("default").expect("missing default account")
     }
-    pub fn is_main(&self, types: Vec<&str>) -> bool {
-        let d = self.default();
-        for ty in types {
-            if d.type_matched(ty) {
-                return true;
-            }
-        }
-        false
+    pub fn is_main(&self, ci_type: &str) -> bool {
+        self.default().ci_type_matched(ci_type)
     }
     pub fn get<'a>(&'a self, name: &str) -> Option<&'a Account> {
         self.0.get(name)

--- a/core/src/config/job.rs
+++ b/core/src/config/job.rs
@@ -565,10 +565,10 @@ pub struct Job {
 }
 impl Job {
     pub fn is_enabled_for_account(&self, account_name: &str) -> bool {
-        match &self.account {
-            Some(a) => a.resolve() == account_name,
-            None => account_name == "default"
-        }
+        self.account_name() == account_name
+    }
+    pub fn account_name(&self) -> String {
+        self.account.as_ref().map_or_else(|| "default".to_string(), |v| v.resolve())
     }
     pub fn runner_os(&self) -> RunnerOS {
         match &self.runner {
@@ -603,9 +603,7 @@ impl Job {
         }
     }
     pub fn ci<'a>(&self, config: &'a config::Config) -> &Box<dyn ci::CI + 'a> {
-        let account = self.account.as_ref().map_or_else(
-            || "default".to_string(), config::Value::resolve_to_string
-        );
+        let account = self.account_name();
         return config.modules.ci_for(&account);
     }
     pub fn run<S>(
@@ -1026,7 +1024,7 @@ impl Jobs {
                 }
             }
         }
-        crate::util::try_debug!("deplo-halt", config.modules.ci_by_default(), runtime_workflow_config.exec, false);
+        crate::util::try_debug!("deplo-halt", config.ci_by_env(), runtime_workflow_config.exec, false);
         Ok(())
     }    
     fn wait_job(
@@ -1100,7 +1098,7 @@ impl Jobs {
     pub fn boot(
         &self, config: &config::Config, runtime_workflow_config: &config::runtime::Workflow, shell: &impl shell::Shell
     ) -> Result<(), Box<dyn Error>> {
-        let (_, ci) = config.ci_by_env();
+        let ci = config.ci_by_env();
         // TODO: support follow_dependency of remote job running.
         // if runtime_workflow_config.job has some value and follow_dependency, 
         // we use Some(runtime_workflow_config.job.name) as first argument of traverse,

--- a/core/src/config/job/runner.rs
+++ b/core/src/config/job/runner.rs
@@ -181,7 +181,7 @@ impl<'a> Runner<'a> {
             job::Runner::Machine{os, ref local_fallback, no_fallback, ..} => {
                 let current_os = shell.detect_os()?;
                 // if deplo is not runnning on CI, we respect configuration no_fallback.
-                // if set to false or ommitted, we use fallback even if os type is matched
+                // if set to false or ommitted (and not running on CI), we use fallback even if os type is matched
                 if os == current_os && (ci.runs_on_service() || no_fallback.unwrap_or(false)) {
                     log::debug!("runner os '{}' is same as current os '{}' and runs on CI or no_fallback is set to true", os, current_os);
                     if let Some(p) = config.setup_deplo_cli(os, shell)? {

--- a/core/src/config/runtime.rs
+++ b/core/src/config/runtime.rs
@@ -295,7 +295,7 @@ impl Workflow {
                 };
                 let mut matches = {
                     let config = config.borrow();
-                    let (_, ci) = config.ci_by_env();
+                    let ci = config.ci_by_env();
                     ci.filter_workflows(trigger)?
                 };
                 if matches.len() == 0 {

--- a/docs/prompt.md
+++ b/docs/prompt.md
@@ -84,3 +84,11 @@ core::config::Module::ci_by_envですが、これはCIの環境上でdeploが動
 
 ======
 --ciがないコマンドでwarningを出す件ですが、ログレベルをdebugにします。コマンドの中には出力をshellで利用するものがあり(eg. deplo job output)、warningだと必ずその出力に混じってしまうからです。どのコマンドが出力を利用するものか、は機械的に判定が難しいので、デフォルトでは--ciが指定
+
+=======
+CIからdeploが起動されるときに、利用すべきciの設定がどれになるかわかるように、core/src/ci/ghaction.rs の generate_config で生成されるワークフローファイル(eg. .github/workflows/deplo-main.yml)に新しい環境変数を追加します。
+
+core/res/ci/ghaction/common_envs.yml.tmpl に DEPLO_CI_ACCOUNT_NAME を追加して generate_config を行うciのaccout_nameで初期化します。
+
+GhAction::runs_on_service, CircleCI::runs_on_serviceは 既存のコードを置き換え、ciのaccount_nameが DEPLO_CI_ACCOUNT_NAME と一致するか、という判定に変更してください。
+

--- a/docs/prompt.md
+++ b/docs/prompt.md
@@ -92,3 +92,21 @@ core/res/ci/ghaction/common_envs.yml.tmpl に DEPLO_CI_ACCOUNT_NAME を追加し
 
 GhAction::runs_on_service, CircleCI::runs_on_serviceは 既存のコードを置き換え、ciのaccount_nameが DEPLO_CI_ACCOUNT_NAME と一致するか、という判定に変更してください。
 
+=======
+core/src/config/ci.rs の Accountsにci_typeという&strを返す関数を追加します。
+GhAction/GhActionAppは"GhAction", CircleCIは"CircleCI"を返します。
+
+Accounts::type_as_str()は以下の３カ所で呼ばれています
+core/src/config.rs
+core/src/ci/ghaction.rs
+core/src/config/ci.rs
+
+それぞれ以下のように修正します。
+core/src/config.rs => ci_type() に変更
+core/src/ci/ghaction.rs => 呼び出すのをやめ、ci_typeを "GhAction" 固定にする
+core/src/config/ci.rs => ci_type() に変更し、呼び出している関数名を type_matched => ci_type_matched に変更
+
+付随してci::Accounts::is_mainを以下のように修正します
+- typesではなく単一のtype(&str)を受け取るようにする
+- circleci側はis_main("CircleCI), ghaction側はis_main("GhAction")と変更
+

--- a/tools/scripts/build_linux.sh
+++ b/tools/scripts/build_linux.sh
@@ -17,7 +17,12 @@ echo "host deplo path=[$(which deplo)]"
 cp $(which deplo) ${ROOT}/tools/docker/bin/host-deplo
 deplo ci getenv --out=${ROOT}/.deplo/env
 echo ${SUNTOMI_VCS_ACCOUNT_KEY} | docker login ghcr.io -u ${SUNTOMI_VCS_ACCOUNT} --password-stdin
-docker buildx create --name mp --bootstrap --use
+if docker buildx inspect mp >/dev/null 2>&1; then
+    docker buildx use mp
+    docker buildx inspect --bootstrap mp >/dev/null
+else
+    docker buildx create --name mp --bootstrap --use
+fi
 docker buildx build --push --platform linux/amd64,linux/arm64 \
     --build-arg DEPLO_RELEASE_VERSION=${DEPLO_RELEASE_VERSION} \
     -t ghcr.io/suntomi/deplo:${DEPLO_RELEASE_VERSION} -f ${ROOT}/tools/docker/Dockerfile ${ROOT}


### PR DESCRIPTION
- introduce DEPLO_CI_ACCOUNT_NAME to completely determine which ci config to use (ambiguity exists in past version) by ci_by_env
- now ci::Account has ci_type() which does not distinguish GhAction/GhActionApp account types
- update action-tmate to 3.24